### PR TITLE
Add net worth dashboard and accounts overview

### DIFF
--- a/frontend/src/api/integrations.ts
+++ b/frontend/src/api/integrations.ts
@@ -1,0 +1,43 @@
+import api from './axios'
+import type {
+  AccountResponse,
+  ProviderStatusResponse,
+  ConnectAccountRequest,
+  SyncResultResponse,
+  NetWorthResponse,
+  NetWorthHistoryResponse,
+} from '@/types'
+
+export const integrationsApi = {
+  getAccounts(): Promise<AccountResponse[]> {
+    return api.get<AccountResponse[]>('/integrations/accounts').then((r) => r.data)
+  },
+
+  getProviders(): Promise<ProviderStatusResponse[]> {
+    return api.get<ProviderStatusResponse[]>('/integrations/providers').then((r) => r.data)
+  },
+
+  connect(data: ConnectAccountRequest): Promise<AccountResponse[]> {
+    return api.post<AccountResponse[]>('/integrations/connect', data).then((r) => r.data)
+  },
+
+  disconnect(credentialId: number): Promise<void> {
+    return api.delete(`/integrations/providers/${credentialId}`).then(() => undefined)
+  },
+
+  sync(credentialId: number): Promise<SyncResultResponse> {
+    return api
+      .post<SyncResultResponse>(`/integrations/providers/${credentialId}/sync`)
+      .then((r) => r.data)
+  },
+
+  getNetWorth(): Promise<NetWorthResponse> {
+    return api.get<NetWorthResponse>('/integrations/net-worth').then((r) => r.data)
+  },
+
+  getNetWorthHistory(days = 30): Promise<NetWorthHistoryResponse> {
+    return api
+      .get<NetWorthHistoryResponse>('/integrations/net-worth/history', { params: { days } })
+      .then((r) => r.data)
+  },
+}

--- a/frontend/src/components/layout/AppSidebar.vue
+++ b/frontend/src/components/layout/AppSidebar.vue
@@ -116,6 +116,16 @@
       <path stroke-linecap="round" stroke-linejoin="round" d="M20.488 9H15V3.512A9.025 9.025 0 0120.488 9z" />
     </svg>`,
   }
+  const IconNetWorth = {
+    template: `<svg fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+      <path stroke-linecap="round" stroke-linejoin="round" d="M13 7h8m0 0v8m0-8l-8 8-4-4-6 6" />
+    </svg>`,
+  }
+  const IconAccounts = {
+    template: `<svg fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+      <path stroke-linecap="round" stroke-linejoin="round" d="M3 10h18M7 15h1m4 0h1m-7 4h12a3 3 0 003-3V8a3 3 0 00-3-3H6a3 3 0 00-3 3v8a3 3 0 003 3z" />
+    </svg>`,
+  }
   const IconSettings = {
     template: `<svg fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
       <path stroke-linecap="round" stroke-linejoin="round" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
@@ -128,6 +138,8 @@
     { name: 'transactions', label: 'Transactions', to: '/transactions', icon: IconTransactions },
     { name: 'categories', label: 'Categories', to: '/categories', icon: IconCategories },
     { name: 'budgets', label: 'Budgets', to: '/budgets', icon: IconBudgets },
+    { name: 'net-worth', label: 'Net Worth', to: '/net-worth', icon: IconNetWorth },
+    { name: 'accounts', label: 'Accounts', to: '/accounts', icon: IconAccounts },
     { name: 'settings', label: 'Settings', to: '/settings', icon: IconSettings },
   ]
 

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -42,6 +42,16 @@ const router = createRouter({
           component: () => import('@/views/BudgetsView.vue'),
         },
         {
+          path: 'net-worth',
+          name: 'net-worth',
+          component: () => import('@/views/NetWorthView.vue'),
+        },
+        {
+          path: 'accounts',
+          name: 'accounts',
+          component: () => import('@/views/AccountsView.vue'),
+        },
+        {
           path: 'settings',
           name: 'settings',
           component: () => import('@/views/SettingsView.vue'),

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -128,3 +128,72 @@ export interface CreateBudgetRequest {
 export interface UpdateBudgetRequest {
   limitAmount: number
 }
+
+// ── Integrations ────────────────────────────────────────────────────────────
+
+export interface AccountResponse {
+  id: number
+  credentialId: number
+  providerType: ProviderType
+  accountType: AccountType
+  displayName: string
+  currency: string
+  balance: number
+  balanceUsd: number
+  asOf: string
+  active: boolean
+}
+
+export type ProviderType = 'COINBASE' | 'BITCOIN_WALLET' | 'M1_FINANCE' | 'MARCUS'
+export type AccountType = 'CRYPTO_WALLET' | 'BROKERAGE' | 'SAVINGS' | 'CHECKING'
+export type SyncStatus = 'NEVER' | 'OK' | 'ERROR'
+
+export interface ProviderStatusResponse {
+  credentialId: number
+  providerType: ProviderType
+  status: SyncStatus
+  lastSyncedAt: string | null
+  errorMessage: string | null
+  accountCount: number
+}
+
+export interface ConnectAccountRequest {
+  providerType: ProviderType
+  credentials: Record<string, string>
+}
+
+export interface SyncResultResponse {
+  providerType: ProviderType
+  syncedAt: string
+  accountsUpdated: number
+  status: SyncStatus
+  errorMessage: string | null
+}
+
+export interface NetWorthResponse {
+  totalNetWorthUsd: number
+  byProvider: ProviderTotal[]
+  byAccountType: AccountTypeTotal[]
+  asOf: string
+}
+
+export interface ProviderTotal {
+  providerType: ProviderType
+  totalUsd: number
+  accountCount: number
+}
+
+export interface AccountTypeTotal {
+  accountType: AccountType
+  totalUsd: number
+  accountCount: number
+}
+
+export interface NetWorthHistoryResponse {
+  dataPoints: NetWorthDataPoint[]
+}
+
+export interface NetWorthDataPoint {
+  date: string
+  totalUsd: number
+}

--- a/frontend/src/views/AccountsView.vue
+++ b/frontend/src/views/AccountsView.vue
@@ -1,0 +1,366 @@
+<template>
+  <div class="px-6 py-8 max-w-7xl mx-auto">
+    <div class="flex items-center justify-between mb-6">
+      <div>
+        <h1 class="text-2xl font-bold text-gray-900">Accounts</h1>
+        <p class="mt-1 text-sm text-gray-500">Manage your connected financial providers.</p>
+      </div>
+      <button
+        class="flex items-center gap-2 px-4 py-2 bg-primary-600 text-white text-sm font-medium rounded-lg hover:bg-primary-700 transition-colors"
+        @click="showConnectModal = true"
+      >
+        <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m8-8H4" />
+        </svg>
+        Connect Provider
+      </button>
+    </div>
+
+    <div v-if="loading" class="flex items-center justify-center h-64 text-gray-400 text-sm">
+      Loading…
+    </div>
+
+    <template v-else>
+      <!-- Providers -->
+      <div v-if="providers.length === 0" class="bg-white rounded-2xl border border-gray-200 flex items-center justify-center h-64 text-gray-400 text-sm">
+        <div class="text-center">
+          <p class="font-medium text-gray-500">No providers connected</p>
+          <p class="text-xs mt-1">Connect Coinbase, Bitcoin, or other accounts to get started.</p>
+        </div>
+      </div>
+
+      <div v-else class="space-y-6">
+        <div
+          v-for="provider in providers"
+          :key="provider.credentialId"
+          class="bg-white rounded-2xl border border-gray-200 overflow-hidden"
+        >
+          <!-- Provider header -->
+          <div class="px-6 py-4 border-b border-gray-100 flex items-center justify-between">
+            <div class="flex items-center gap-3">
+              <div
+                class="w-10 h-10 rounded-lg flex items-center justify-center text-xs font-bold text-white"
+                :class="providerColor(provider.providerType)"
+              >
+                {{ providerIcon(provider.providerType) }}
+              </div>
+              <div>
+                <p class="text-sm font-semibold text-gray-900">{{ providerLabel(provider.providerType) }}</p>
+                <div class="flex items-center gap-2 text-xs text-gray-500">
+                  <span
+                    class="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full text-xs font-medium"
+                    :class="statusClass(provider.status)"
+                  >
+                    {{ provider.status }}
+                  </span>
+                  <span v-if="provider.lastSyncedAt">
+                    Synced {{ timeAgo(provider.lastSyncedAt) }}
+                  </span>
+                </div>
+              </div>
+            </div>
+            <div class="flex items-center gap-2">
+              <button
+                class="px-3 py-1.5 text-xs font-medium text-primary-700 border border-primary-200 rounded-lg hover:bg-primary-50 transition-colors disabled:opacity-50"
+                :disabled="syncing === provider.credentialId"
+                @click="syncProvider(provider.credentialId)"
+              >
+                {{ syncing === provider.credentialId ? 'Syncing…' : 'Sync' }}
+              </button>
+              <button
+                class="px-3 py-1.5 text-xs font-medium text-red-700 border border-red-200 rounded-lg hover:bg-red-50 transition-colors"
+                @click="openDisconnectModal(provider)"
+              >
+                Disconnect
+              </button>
+            </div>
+          </div>
+
+          <!-- Provider error -->
+          <div v-if="provider.errorMessage" class="px-6 py-2 bg-red-50 text-sm text-red-700">
+            {{ provider.errorMessage }}
+          </div>
+
+          <!-- Accounts under this provider -->
+          <div v-if="accountsByProvider(provider.credentialId).length > 0">
+            <table class="w-full text-sm">
+              <thead>
+                <tr class="border-b border-gray-50">
+                  <th class="px-6 py-2 text-left text-xs font-semibold text-gray-500 uppercase">Account</th>
+                  <th class="px-6 py-2 text-left text-xs font-semibold text-gray-500 uppercase">Type</th>
+                  <th class="px-6 py-2 text-right text-xs font-semibold text-gray-500 uppercase">Balance</th>
+                  <th class="px-6 py-2 text-right text-xs font-semibold text-gray-500 uppercase">USD Value</th>
+                </tr>
+              </thead>
+              <tbody class="divide-y divide-gray-50">
+                <tr
+                  v-for="acc in accountsByProvider(provider.credentialId)"
+                  :key="acc.id"
+                  class="hover:bg-gray-50 transition-colors"
+                >
+                  <td class="px-6 py-3 text-gray-800 font-medium">{{ acc.displayName }}</td>
+                  <td class="px-6 py-3 text-gray-500">{{ accountTypeLabel(acc.accountType) }}</td>
+                  <td class="px-6 py-3 text-right tabular-nums text-gray-600">
+                    {{ acc.balance.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 8 }) }} {{ acc.currency }}
+                  </td>
+                  <td class="px-6 py-3 text-right font-semibold tabular-nums text-gray-900">
+                    {{ formatMoney(acc.balanceUsd) }}
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+          <div v-else class="px-6 py-4 text-sm text-gray-400">No accounts discovered yet.</div>
+        </div>
+      </div>
+    </template>
+
+    <!-- Connect Provider modal -->
+    <div
+      v-if="showConnectModal"
+      class="fixed inset-0 z-50 flex items-center justify-center bg-gray-900/50"
+      @mousedown.self="showConnectModal = false"
+    >
+      <div class="bg-white rounded-2xl shadow-xl w-full max-w-md mx-4 p-6">
+        <div class="flex items-center justify-between mb-5">
+          <h2 class="text-lg font-semibold text-gray-900">Connect Provider</h2>
+          <button class="text-gray-400 hover:text-gray-600" @click="showConnectModal = false">
+            <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        <form class="space-y-4" @submit.prevent="submitConnect">
+          <div>
+            <label class="block text-sm font-medium text-gray-700 mb-1">Provider</label>
+            <select
+              v-model="connectForm.providerType"
+              required
+              class="w-full px-3 py-2 text-sm border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+            >
+              <option value="" disabled>Select a provider</option>
+              <option value="COINBASE">Coinbase</option>
+              <option value="BITCOIN_WALLET">Bitcoin Wallet</option>
+              <option value="M1_FINANCE">M1 Finance</option>
+              <option value="MARCUS">Marcus by Goldman Sachs</option>
+            </select>
+          </div>
+
+          <!-- Dynamic credential fields -->
+          <template v-if="connectForm.providerType === 'COINBASE'">
+            <div>
+              <label class="block text-sm font-medium text-gray-700 mb-1">API Key</label>
+              <input v-model="connectForm.credentials.apiKey" type="text" required
+                class="w-full px-3 py-2 text-sm border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent">
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-gray-700 mb-1">API Secret</label>
+              <input v-model="connectForm.credentials.apiSecret" type="password" required
+                class="w-full px-3 py-2 text-sm border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent">
+            </div>
+          </template>
+          <template v-else-if="connectForm.providerType === 'BITCOIN_WALLET'">
+            <div>
+              <label class="block text-sm font-medium text-gray-700 mb-1">Bitcoin Address</label>
+              <input v-model="connectForm.credentials.address" type="text" required placeholder="bc1..."
+                class="w-full px-3 py-2 text-sm border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent">
+            </div>
+          </template>
+          <template v-else-if="connectForm.providerType">
+            <div class="text-sm text-gray-500 bg-gray-50 rounded-lg p-3">
+              Plaid integration coming soon. This provider will connect via Plaid Link.
+            </div>
+          </template>
+
+          <p v-if="connectFormError" class="text-sm text-red-600">{{ connectFormError }}</p>
+
+          <div class="flex gap-3 pt-1">
+            <button type="button"
+              class="flex-1 px-4 py-2 text-sm font-medium text-gray-700 border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors"
+              @click="showConnectModal = false">
+              Cancel
+            </button>
+            <button type="submit" :disabled="submittingConnect || !connectForm.providerType"
+              class="flex-1 px-4 py-2 text-sm font-medium text-white bg-primary-600 rounded-lg hover:bg-primary-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors">
+              {{ submittingConnect ? 'Connecting…' : 'Connect' }}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+
+    <!-- Disconnect confirmation modal -->
+    <div
+      v-if="showDisconnectModal"
+      class="fixed inset-0 z-50 flex items-center justify-center bg-gray-900/50"
+      @mousedown.self="showDisconnectModal = false"
+    >
+      <div class="bg-white rounded-2xl shadow-xl w-full max-w-sm mx-4 p-6">
+        <h2 class="text-lg font-semibold text-gray-900 mb-2">Disconnect Provider</h2>
+        <p class="text-sm text-gray-600 mb-5">
+          Disconnect <span class="font-medium">{{ providerLabel(disconnectTarget?.providerType ?? 'COINBASE') }}</span>?
+          Account data will be removed.
+        </p>
+        <p v-if="disconnectError" class="text-sm text-red-600 mb-4">{{ disconnectError }}</p>
+        <div class="flex gap-3">
+          <button type="button"
+            class="flex-1 px-4 py-2 text-sm font-medium text-gray-700 border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors"
+            @click="showDisconnectModal = false">
+            Cancel
+          </button>
+          <button type="button" :disabled="submittingDisconnect"
+            class="flex-1 px-4 py-2 text-sm font-medium text-white bg-red-600 rounded-lg hover:bg-red-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+            @click="confirmDisconnect">
+            {{ submittingDisconnect ? 'Disconnecting…' : 'Disconnect' }}
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+  import { ref, reactive, onMounted } from 'vue'
+  import { integrationsApi } from '@/api/integrations'
+  import { formatMoney } from '@/utils/formatting'
+  import type { AccountResponse, ProviderStatusResponse, ProviderType, AccountType } from '@/types'
+
+  const loading = ref(false)
+  const providers = ref<ProviderStatusResponse[]>([])
+  const accounts = ref<AccountResponse[]>([])
+  const syncing = ref<number | null>(null)
+
+  function providerLabel(type: ProviderType): string {
+    const map: Record<ProviderType, string> = {
+      COINBASE: 'Coinbase',
+      BITCOIN_WALLET: 'Bitcoin Wallet',
+      M1_FINANCE: 'M1 Finance',
+      MARCUS: 'Marcus by Goldman Sachs',
+    }
+    return map[type] ?? type
+  }
+
+  function providerIcon(type: ProviderType): string {
+    const map: Record<ProviderType, string> = { COINBASE: 'CB', BITCOIN_WALLET: 'BTC', M1_FINANCE: 'M1', MARCUS: 'GS' }
+    return map[type] ?? '?'
+  }
+
+  function providerColor(type: ProviderType): string {
+    const map: Record<ProviderType, string> = { COINBASE: 'bg-blue-600', BITCOIN_WALLET: 'bg-orange-500', M1_FINANCE: 'bg-emerald-600', MARCUS: 'bg-indigo-600' }
+    return map[type] ?? 'bg-gray-500'
+  }
+
+  function accountTypeLabel(type: AccountType): string {
+    const map: Record<AccountType, string> = { CRYPTO_WALLET: 'Crypto', BROKERAGE: 'Brokerage', SAVINGS: 'Savings', CHECKING: 'Checking' }
+    return map[type] ?? type
+  }
+
+  function statusClass(status: string): string {
+    if (status === 'OK') return 'bg-emerald-100 text-emerald-700'
+    if (status === 'ERROR') return 'bg-red-100 text-red-700'
+    return 'bg-gray-100 text-gray-600'
+  }
+
+  function timeAgo(iso: string): string {
+    const diff = Date.now() - new Date(iso).getTime()
+    const mins = Math.floor(diff / 60000)
+    if (mins < 1) return 'just now'
+    if (mins < 60) return `${mins}m ago`
+    const hrs = Math.floor(mins / 60)
+    if (hrs < 24) return `${hrs}h ago`
+    return `${Math.floor(hrs / 24)}d ago`
+  }
+
+  function accountsByProvider(credentialId: number): AccountResponse[] {
+    return accounts.value.filter((a) => a.credentialId === credentialId && a.active)
+  }
+
+  async function syncProvider(credentialId: number) {
+    syncing.value = credentialId
+    try {
+      await integrationsApi.sync(credentialId)
+      await loadData()
+    } catch {
+      // Error shown via provider status
+    } finally {
+      syncing.value = null
+    }
+  }
+
+  // ── Connect ────────────────────────────────────────────────────────────────
+
+  const showConnectModal = ref(false)
+  const submittingConnect = ref(false)
+  const connectFormError = ref('')
+
+  const connectForm = reactive({
+    providerType: '' as ProviderType | '',
+    credentials: {} as Record<string, string>,
+  })
+
+  async function submitConnect() {
+    if (!connectForm.providerType) return
+    connectFormError.value = ''
+    submittingConnect.value = true
+    try {
+      await integrationsApi.connect({
+        providerType: connectForm.providerType,
+        credentials: connectForm.credentials,
+      })
+      showConnectModal.value = false
+      connectForm.providerType = ''
+      connectForm.credentials = {}
+      await loadData()
+    } catch {
+      connectFormError.value = 'Failed to connect provider. Check your credentials.'
+    } finally {
+      submittingConnect.value = false
+    }
+  }
+
+  // ── Disconnect ─────────────────────────────────────────────────────────────
+
+  const showDisconnectModal = ref(false)
+  const submittingDisconnect = ref(false)
+  const disconnectError = ref('')
+  const disconnectTarget = ref<ProviderStatusResponse | null>(null)
+
+  function openDisconnectModal(provider: ProviderStatusResponse) {
+    disconnectTarget.value = provider
+    disconnectError.value = ''
+    showDisconnectModal.value = true
+  }
+
+  async function confirmDisconnect() {
+    if (!disconnectTarget.value) return
+    submittingDisconnect.value = true
+    disconnectError.value = ''
+    try {
+      await integrationsApi.disconnect(disconnectTarget.value.credentialId)
+      showDisconnectModal.value = false
+      await loadData()
+    } catch {
+      disconnectError.value = 'Failed to disconnect. Please try again.'
+    } finally {
+      submittingDisconnect.value = false
+    }
+  }
+
+  async function loadData() {
+    const [p, a] = await Promise.all([integrationsApi.getProviders(), integrationsApi.getAccounts()])
+    providers.value = p
+    accounts.value = a
+  }
+
+  onMounted(async () => {
+    loading.value = true
+    try {
+      await loadData()
+    } catch {
+      // Empty state shown
+    } finally {
+      loading.value = false
+    }
+  })
+</script>

--- a/frontend/src/views/NetWorthView.vue
+++ b/frontend/src/views/NetWorthView.vue
@@ -1,0 +1,191 @@
+<template>
+  <div class="px-6 py-8 max-w-7xl mx-auto">
+    <div class="mb-6">
+      <h1 class="text-2xl font-bold text-gray-900">Net Worth</h1>
+      <p class="mt-1 text-sm text-gray-500">Your total wealth across all connected accounts.</p>
+    </div>
+
+    <div v-if="loading" class="flex items-center justify-center h-64 text-gray-400 text-sm">
+      Loading…
+    </div>
+
+    <template v-else>
+      <!-- Total net worth card -->
+      <div class="bg-white rounded-2xl border border-gray-200 p-6 mb-6">
+        <p class="text-sm text-gray-500 mb-1">Total Net Worth</p>
+        <p class="text-3xl font-bold text-gray-900">{{ formatMoney(netWorth?.totalNetWorthUsd ?? 0) }}</p>
+        <p v-if="netWorth?.asOf" class="text-xs text-gray-400 mt-2">
+          As of {{ new Date(netWorth.asOf).toLocaleString() }}
+        </p>
+      </div>
+
+      <!-- Breakdown cards -->
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6">
+        <!-- By Provider -->
+        <div class="bg-white rounded-2xl border border-gray-200 p-6">
+          <h2 class="text-sm font-semibold text-gray-700 uppercase tracking-wide mb-4">By Provider</h2>
+          <div v-if="(netWorth?.byProvider ?? []).length === 0" class="text-sm text-gray-400">
+            No connected providers.
+          </div>
+          <div v-else class="space-y-3">
+            <div
+              v-for="p in netWorth!.byProvider"
+              :key="p.providerType"
+              class="flex items-center justify-between"
+            >
+              <div class="flex items-center gap-3">
+                <div
+                  class="w-8 h-8 rounded-lg flex items-center justify-center text-xs font-bold text-white"
+                  :class="providerColor(p.providerType)"
+                >
+                  {{ providerIcon(p.providerType) }}
+                </div>
+                <div>
+                  <p class="text-sm font-medium text-gray-900">{{ providerLabel(p.providerType) }}</p>
+                  <p class="text-xs text-gray-500">{{ p.accountCount }} account{{ p.accountCount !== 1 ? 's' : '' }}</p>
+                </div>
+              </div>
+              <p class="text-sm font-semibold text-gray-900 tabular-nums">{{ formatMoney(p.totalUsd) }}</p>
+            </div>
+          </div>
+        </div>
+
+        <!-- By Account Type -->
+        <div class="bg-white rounded-2xl border border-gray-200 p-6">
+          <h2 class="text-sm font-semibold text-gray-700 uppercase tracking-wide mb-4">By Account Type</h2>
+          <div v-if="(netWorth?.byAccountType ?? []).length === 0" class="text-sm text-gray-400">
+            No accounts yet.
+          </div>
+          <div v-else class="space-y-3">
+            <div
+              v-for="a in netWorth!.byAccountType"
+              :key="a.accountType"
+              class="flex items-center justify-between"
+            >
+              <div>
+                <p class="text-sm font-medium text-gray-900">{{ accountTypeLabel(a.accountType) }}</p>
+                <p class="text-xs text-gray-500">{{ a.accountCount }} account{{ a.accountCount !== 1 ? 's' : '' }}</p>
+              </div>
+              <p class="text-sm font-semibold text-gray-900 tabular-nums">{{ formatMoney(a.totalUsd) }}</p>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- History chart (simple table for now) -->
+      <div class="bg-white rounded-2xl border border-gray-200 p-6">
+        <div class="flex items-center justify-between mb-4">
+          <h2 class="text-sm font-semibold text-gray-700 uppercase tracking-wide">History</h2>
+          <select
+            v-model.number="historyDays"
+            class="text-sm border border-gray-300 rounded-lg px-3 py-1.5 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+            @change="loadHistory"
+          >
+            <option :value="7">7 days</option>
+            <option :value="30">30 days</option>
+            <option :value="90">90 days</option>
+            <option :value="365">1 year</option>
+          </select>
+        </div>
+
+        <div v-if="historyLoading" class="text-sm text-gray-400 text-center py-8">Loading history…</div>
+        <div v-else-if="history.length === 0" class="text-sm text-gray-400 text-center py-8">
+          No history data yet. Connect accounts and sync to start tracking.
+        </div>
+        <div v-else class="overflow-x-auto">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="border-b border-gray-100">
+                <th class="text-left px-4 py-2 text-xs font-semibold text-gray-500 uppercase">Date</th>
+                <th class="text-right px-4 py-2 text-xs font-semibold text-gray-500 uppercase">Net Worth</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-gray-50">
+              <tr v-for="dp in history" :key="dp.date" class="hover:bg-gray-50">
+                <td class="px-4 py-2 text-gray-600">{{ dp.date }}</td>
+                <td class="px-4 py-2 text-right font-semibold text-gray-900 tabular-nums">{{ formatMoney(dp.totalUsd) }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </template>
+  </div>
+</template>
+
+<script setup lang="ts">
+  import { ref, onMounted } from 'vue'
+  import { integrationsApi } from '@/api/integrations'
+  import { formatMoney } from '@/utils/formatting'
+  import type { NetWorthResponse, NetWorthDataPoint, ProviderType, AccountType } from '@/types'
+
+  const loading = ref(false)
+  const netWorth = ref<NetWorthResponse | null>(null)
+  const history = ref<NetWorthDataPoint[]>([])
+  const historyDays = ref(30)
+  const historyLoading = ref(false)
+
+  function providerLabel(type: ProviderType): string {
+    const map: Record<ProviderType, string> = {
+      COINBASE: 'Coinbase',
+      BITCOIN_WALLET: 'Bitcoin',
+      M1_FINANCE: 'M1 Finance',
+      MARCUS: 'Marcus',
+    }
+    return map[type] ?? type
+  }
+
+  function providerIcon(type: ProviderType): string {
+    const map: Record<ProviderType, string> = {
+      COINBASE: 'CB',
+      BITCOIN_WALLET: 'BTC',
+      M1_FINANCE: 'M1',
+      MARCUS: 'GS',
+    }
+    return map[type] ?? '?'
+  }
+
+  function providerColor(type: ProviderType): string {
+    const map: Record<ProviderType, string> = {
+      COINBASE: 'bg-blue-600',
+      BITCOIN_WALLET: 'bg-orange-500',
+      M1_FINANCE: 'bg-emerald-600',
+      MARCUS: 'bg-indigo-600',
+    }
+    return map[type] ?? 'bg-gray-500'
+  }
+
+  function accountTypeLabel(type: AccountType): string {
+    const map: Record<AccountType, string> = {
+      CRYPTO_WALLET: 'Crypto',
+      BROKERAGE: 'Brokerage',
+      SAVINGS: 'Savings',
+      CHECKING: 'Checking',
+    }
+    return map[type] ?? type
+  }
+
+  async function loadHistory() {
+    historyLoading.value = true
+    try {
+      const resp = await integrationsApi.getNetWorthHistory(historyDays.value)
+      history.value = resp.dataPoints
+    } catch {
+      history.value = []
+    } finally {
+      historyLoading.value = false
+    }
+  }
+
+  onMounted(async () => {
+    loading.value = true
+    try {
+      const [nw] = await Promise.all([integrationsApi.getNetWorth(), loadHistory()])
+      netWorth.value = nw
+    } catch {
+      // Empty state shown
+    } finally {
+      loading.value = false
+    }
+  })
+</script>


### PR DESCRIPTION
## Summary
- Add integrations API client with all endpoints (connect, sync, disconnect, net worth, history)
- Create Net Worth dashboard with total, provider/type breakdown, and history table
- Create Accounts overview with provider cards, account tables, connect/sync/disconnect modals
- Add routes and sidebar nav items

Closes #16
Closes #17

## Test plan
- [x] Frontend builds clean
- [x] Net worth page renders empty state when no accounts
- [x] Accounts page shows connect modal with provider-specific credential fields

?? Generated with [Claude Code](https://claude.com/claude-code)