### PR TITLE
Add API integration tests with full Spring context

### DIFF
--- a/backend/src/test/java/com/keybudget/integration/BudgetApiIntegrationTest.java
+++ b/backend/src/test/java/com/keybudget/integration/BudgetApiIntegrationTest.java
@@ -16,6 +16,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
@@ -32,6 +33,11 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @SpringBootTest
 @AutoConfigureMockMvc
 @Transactional
+@TestPropertySource(properties = {
+        "spring.security.oauth2.client.registration.google.client-id=test-client-id",
+        "spring.security.oauth2.client.registration.google.client-secret=test-client-secret",
+        "spring.security.oauth2.client.registration.google.scope=openid,email,profile"
+})
 class BudgetApiIntegrationTest {
 
     @Autowired

--- a/backend/src/test/java/com/keybudget/integration/CategoryApiIntegrationTest.java
+++ b/backend/src/test/java/com/keybudget/integration/CategoryApiIntegrationTest.java
@@ -14,6 +14,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.transaction.annotation.Transactional;
 
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
@@ -27,6 +28,11 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @SpringBootTest
 @AutoConfigureMockMvc
 @Transactional
+@TestPropertySource(properties = {
+        "spring.security.oauth2.client.registration.google.client-id=test-client-id",
+        "spring.security.oauth2.client.registration.google.client-secret=test-client-secret",
+        "spring.security.oauth2.client.registration.google.scope=openid,email,profile"
+})
 class CategoryApiIntegrationTest {
 
     @Autowired

--- a/backend/src/test/java/com/keybudget/integration/TransactionApiIntegrationTest.java
+++ b/backend/src/test/java/com/keybudget/integration/TransactionApiIntegrationTest.java
@@ -17,6 +17,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
@@ -33,6 +34,11 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @SpringBootTest
 @AutoConfigureMockMvc
 @Transactional
+@TestPropertySource(properties = {
+        "spring.security.oauth2.client.registration.google.client-id=test-client-id",
+        "spring.security.oauth2.client.registration.google.client-secret=test-client-secret",
+        "spring.security.oauth2.client.registration.google.scope=openid,email,profile"
+})
 class TransactionApiIntegrationTest {
 
     @Autowired

--- a/backend/src/test/resources/application.properties
+++ b/backend/src/test/resources/application.properties
@@ -24,3 +24,6 @@ spring.jpa.hibernate.ddl-auto=create-drop
 
 # Disable Flyway for tests — H2 schema managed by Hibernate
 spring.flyway.enabled=false
+
+# Required by AuthController — secure flag must be false in test (no HTTPS)
+app.cookie.secure=false


### PR DESCRIPTION
## What
- 3 new @SpringBootTest integration test classes:
  - CategoryApiIntegrationTest: CRUD lifecycle, auth isolation, validation (7 tests)
  - TransactionApiIntegrationTest: CRUD, monthly summary, auth, validation (7 tests)
  - BudgetApiIntegrationTest: CRUD, duplicate detection, auth (5 tests)
- Tests use real H2 database with @Transactional rollback
- Full stack: controller ? service ? repository ? H2

## Why
Existing tests are all slice/unit tests. Integration tests verify the full API stack works end-to-end including security, validation, DB queries, and response serialization.

Closes #21

## Test plan
- [ ] All new integration tests pass
- [ ] All existing 177 tests still pass
- [ ] No test interference (each test is @Transactional)