### PR TITLE
Fix CSRF test failures in importCsv and updateCurrency

### DIFF
--- a/backend/src/test/java/com/keybudget/transaction/TransactionControllerTest.java
+++ b/backend/src/test/java/com/keybudget/transaction/TransactionControllerTest.java
@@ -18,6 +18,8 @@ import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.web.servlet.MockMvc;
 
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+
 import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
@@ -72,7 +74,8 @@ class TransactionControllerTest {
         MockMultipartFile file = new MockMultipartFile("file", "test.csv", "text/csv",
                 "Date,Description,Amount\n".getBytes(StandardCharsets.UTF_8));
 
-        mockMvc.perform(multipart("/api/v1/transactions/import").file(file))
+        // CSRF token provided so the CSRF filter passes; auth check then returns 401
+        mockMvc.perform(multipart("/api/v1/transactions/import").file(file).with(csrf()))
                 .andExpect(status().isUnauthorized());
     }
 

--- a/backend/src/test/java/com/keybudget/user/UserControllerTest.java
+++ b/backend/src/test/java/com/keybudget/user/UserControllerTest.java
@@ -80,7 +80,9 @@ class UserControllerTest {
 
     @Test
     void updateCurrency_givenNoJwt_401() throws Exception {
+        // CSRF token provided so the CSRF filter passes; auth check then returns 401
         mockMvc.perform(put("/api/v1/users/me/currency")
+                        .with(csrf())
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"currency\":\"EUR\"}"))
                 .andExpect(status().isUnauthorized());


### PR DESCRIPTION
## What
Add missing `.with(csrf())` to two slice tests that expected 401 but got 403.

## Why
`@WebMvcTest` enables CSRF by default. Without a CSRF token, the CSRF filter returns 403 before the auth entry point can return 401. Adding `.with(csrf())` lets the auth filter fire correctly.

## Test plan
- [ ] `TransactionControllerTest.importCsv_givenNoJwt_401` passes
- [ ] `UserControllerTest.updateCurrency_givenNoJwt_401` passes
- [ ] Full test suite: 214/214 pass (0 failures)

Closes #60

?? Generated with [Claude Code](https://claude.com/claude-code)