### PR TITLE
Extract REFRESH_TOKEN_MAX_AGE_SECONDS to config

### DIFF
--- a/backend/src/main/java/com/keybudget/auth/AuthController.java
+++ b/backend/src/main/java/com/keybudget/auth/AuthController.java
@@ -20,22 +20,23 @@ import java.time.Instant;
 @RequestMapping("/api/v1/auth")
 public class AuthController {
 
-    private static final int REFRESH_TOKEN_MAX_AGE_SECONDS = 7 * 24 * 3600;
-
     private final JwtService jwtService;
     private final UserService userService;
     private final RefreshTokenService refreshTokenService;
     private final boolean secureCookie;
+    private final int refreshTokenMaxAge;
 
     public AuthController(
             JwtService jwtService,
             UserService userService,
             RefreshTokenService refreshTokenService,
-            @Value("${app.cookie.secure}") boolean secureCookie) {
+            @Value("${app.cookie.secure}") boolean secureCookie,
+            @Value("${app.refresh-token.max-age-seconds}") int refreshTokenMaxAge) {
         this.jwtService = jwtService;
         this.userService = userService;
         this.refreshTokenService = refreshTokenService;
         this.secureCookie = secureCookie;
+        this.refreshTokenMaxAge = refreshTokenMaxAge;
     }
 
     @PostMapping("/refresh")
@@ -74,13 +75,13 @@ public class AuthController {
         String newRefreshToken = jwtService.issueRefreshToken(user);
 
         refreshTokenService.store(jwtService.extractJti(newRefreshToken), userId,
-                Instant.now().plusSeconds(REFRESH_TOKEN_MAX_AGE_SECONDS), storedToken.getFamilyId());
+                Instant.now().plusSeconds(refreshTokenMaxAge), storedToken.getFamilyId());
 
         ResponseCookie refreshCookie = ResponseCookie.from("refresh_token", newRefreshToken)
                 .httpOnly(true)
                 .secure(secureCookie)
                 .path("/api/v1/auth/")
-                .maxAge(REFRESH_TOKEN_MAX_AGE_SECONDS)
+                .maxAge(refreshTokenMaxAge)
                 .sameSite("Strict")
                 .build();
         response.addHeader(HttpHeaders.SET_COOKIE, refreshCookie.toString());

--- a/backend/src/main/java/com/keybudget/auth/JwtServiceImpl.java
+++ b/backend/src/main/java/com/keybudget/auth/JwtServiceImpl.java
@@ -20,19 +20,20 @@ import java.util.UUID;
 @Service
 public class JwtServiceImpl implements JwtService {
 
-    private static final long ACCESS_TOKEN_EXPIRY_SECONDS = 15 * 60;         // 15 minutes
-    private static final long REFRESH_TOKEN_EXPIRY_SECONDS = 7 * 24 * 3600;  // 7 days
+    private static final long ACCESS_TOKEN_EXPIRY_SECONDS = 15 * 60;  // 15 minutes
 
     private final PrivateKey privateKey;
     private final PublicKey publicKey;
     private final String issuer;
     private final String audience;
+    private final long refreshTokenMaxAge;
 
     public JwtServiceImpl(
             @Value("${app.jwt.private-key}") String privateKeyBase64,
             @Value("${app.jwt.public-key}") String publicKeyBase64,
             @Value("${app.jwt.issuer}") String issuer,
-            @Value("${app.jwt.audience}") String audience) throws Exception {
+            @Value("${app.jwt.audience}") String audience,
+            @Value("${app.refresh-token.max-age-seconds}") long refreshTokenMaxAge) throws Exception {
         KeyFactory kf = KeyFactory.getInstance("RSA");
         this.privateKey = kf.generatePrivate(
                 new PKCS8EncodedKeySpec(Base64.getDecoder().decode(privateKeyBase64)));
@@ -40,6 +41,7 @@ public class JwtServiceImpl implements JwtService {
                 new X509EncodedKeySpec(Base64.getDecoder().decode(publicKeyBase64)));
         this.issuer = issuer;
         this.audience = audience;
+        this.refreshTokenMaxAge = refreshTokenMaxAge;
     }
 
     @Override
@@ -49,7 +51,7 @@ public class JwtServiceImpl implements JwtService {
 
     @Override
     public String issueRefreshToken(User user) {
-        return buildToken(user, REFRESH_TOKEN_EXPIRY_SECONDS, "refresh");
+        return buildToken(user, refreshTokenMaxAge, "refresh");
     }
 
     @Override

--- a/backend/src/main/java/com/keybudget/auth/OAuth2SuccessHandler.java
+++ b/backend/src/main/java/com/keybudget/auth/OAuth2SuccessHandler.java
@@ -21,25 +21,26 @@ import java.util.UUID;
 @Component
 public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
-    private static final int REFRESH_TOKEN_MAX_AGE_SECONDS = 7 * 24 * 3600;
-
     private final UserService userService;
     private final JwtService jwtService;
     private final RefreshTokenService refreshTokenService;
     private final String frontendUrl;
     private final boolean secureCookie;
+    private final int refreshTokenMaxAge;
 
     public OAuth2SuccessHandler(
             UserService userService,
             JwtService jwtService,
             RefreshTokenService refreshTokenService,
             @Value("${app.frontend-url}") String frontendUrl,
-            @Value("${app.cookie.secure}") boolean secureCookie) {
+            @Value("${app.cookie.secure}") boolean secureCookie,
+            @Value("${app.refresh-token.max-age-seconds}") int refreshTokenMaxAge) {
         this.userService = userService;
         this.jwtService = jwtService;
         this.refreshTokenService = refreshTokenService;
         this.frontendUrl = frontendUrl;
         this.secureCookie = secureCookie;
+        this.refreshTokenMaxAge = refreshTokenMaxAge;
     }
 
     @Override
@@ -62,14 +63,14 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 
         String jti = jwtService.extractJti(refreshToken);
         String familyId = UUID.randomUUID().toString();
-        refreshTokenService.store(jti, user.getId(), Instant.now().plusSeconds(7 * 24 * 3600), familyId);
+        refreshTokenService.store(jti, user.getId(), Instant.now().plusSeconds(refreshTokenMaxAge), familyId);
 
         // Refresh token: HttpOnly cookie — not accessible to JavaScript
         ResponseCookie refreshCookie = ResponseCookie.from("refresh_token", refreshToken)
                 .httpOnly(true)
                 .secure(secureCookie)
                 .path("/api/v1/auth/")
-                .maxAge(REFRESH_TOKEN_MAX_AGE_SECONDS)
+                .maxAge(refreshTokenMaxAge)
                 .sameSite("Strict")
                 .build();
         response.addHeader(HttpHeaders.SET_COOKIE, refreshCookie.toString());

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -9,5 +9,8 @@ server.error.include-binding-errors=never
 management.endpoints.web.exposure.include=health
 management.endpoint.health.show-details=never
 
+# Refresh token lifetime (seconds) — 7 days
+app.refresh-token.max-age-seconds=604800
+
 # Default to dev profile; override with SPRING_PROFILES_ACTIVE=prod in production
 spring.profiles.active=dev


### PR DESCRIPTION
## What
Replace duplicate `REFRESH_TOKEN_MAX_AGE_SECONDS` constants with a single config property `app.refresh-token.max-age-seconds`.

## Why
The 7-day refresh token lifetime was hardcoded in three places (AuthController, OAuth2SuccessHandler, JwtServiceImpl). Single source of truth prevents drift and makes it configurable per environment.

## Test plan
- [ ] Backend starts with dev profile
- [ ] Refresh token flow works (cookie max-age = 604800s)
- [ ] All existing auth tests pass

Closes #58

?? Generated with [Claude Code](https://claude.com/claude-code)