### PR TITLE
Remove unused Caffeine cache dependency

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -97,16 +97,6 @@
             <artifactId>spring-boot-starter-webflux</artifactId>
         </dependency>
 
-        <!-- Caffeine cache -->
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-cache</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.github.ben-manes.caffeine</groupId>
-            <artifactId>caffeine</artifactId>
-        </dependency>
-
         <!-- Actuator -->
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/backend/src/main/java/com/keybudget/KeyBudgetApplication.java
+++ b/backend/src/main/java/com/keybudget/KeyBudgetApplication.java
@@ -2,11 +2,9 @@ package com.keybudget;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
-@EnableCaching
 @EnableScheduling
 public class KeyBudgetApplication {
 


### PR DESCRIPTION
## What
Remove `spring-boot-starter-cache` and `caffeine` from pom.xml. Remove `@EnableCaching` from KeyBudgetApplication.

## Why
No `@Cacheable` annotations exist in the codebase. WebFlux is kept because `WebClient` is actively used by Bitcoin and Coinbase integration providers.

## Test plan
- [ ] `./mvnw package` succeeds
- [ ] Application starts with dev profile
- [ ] Integration provider tests pass

Closes #59

?? Generated with [Claude Code](https://claude.com/claude-code)