### PR TITLE
Add backend/.env.example for local dev setup

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,25 @@
+# KeyBudget Backend — Local Dev Environment
+# Copy to .env and fill in values: cp .env.example .env
+# NEVER commit .env to version control.
+
+# --- Google OAuth2 ---
+# Create credentials at: https://console.cloud.google.com -> APIs & Services -> Credentials
+# See docs/google-oauth-setup.md for step-by-step guide
+GOOGLE_CLIENT_ID=your-client-id.apps.googleusercontent.com
+GOOGLE_CLIENT_SECRET=your-client-secret
+
+# --- JWT RSA Keys (base64-encoded DER) ---
+# Generate with: bash ../scripts/generate-keys.sh
+# Or start-dev.sh auto-generates ephemeral keys if these are empty
+JWT_PRIVATE_KEY=
+JWT_PUBLIC_KEY=
+
+# --- AES-256 Encryption Key ---
+# Generate with: openssl rand -base64 32
+# Or start-dev.sh auto-generates if empty
+ENCRYPTION_KEY=
+
+# --- Plaid (optional — only needed for M1/Marcus integrations) ---
+# Sign up free at: https://dashboard.plaid.com
+PLAID_CLIENT_ID=not-configured
+PLAID_SECRET=not-configured


### PR DESCRIPTION
## What
Add `backend/.env.example` documenting all required env vars with setup instructions.

## Why
New developers need to know which env vars to set and where to get credential values. The root `.env.example` is for Docker Compose; this one is for local `./mvnw spring-boot:run` usage.

## Test plan
- [ ] `cp backend/.env.example backend/.env` creates a valid template
- [ ] All required vars are documented with instructions
- [ ] `.env` remains gitignored

Closes #63

?? Generated with [Claude Code](https://claude.com/claude-code)