### PR TITLE
Add CSV import duplicate detection

### DIFF
--- a/backend/src/main/java/com/keybudget/transaction/CsvImportService.java
+++ b/backend/src/main/java/com/keybudget/transaction/CsvImportService.java
@@ -4,6 +4,7 @@ import com.keybudget.category.Category;
 import com.keybudget.category.CategoryRepository;
 import com.keybudget.category.CategoryType;
 import com.keybudget.transaction.dto.CsvImportResult;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -12,14 +13,28 @@ import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
+import java.util.HexFormat;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+/**
+ * Parses and persists transactions from an uploaded CSV file.
+ *
+ * <p>CSV format (header required): {@code Date, Description, Amount}
+ * <ul>
+ *   <li>Negative amounts are treated as EXPENSE; positive as INCOME.</li>
+ *   <li>A SHA-256 hash is computed for each row and stored in {@code import_hash}.
+ *       Rows whose hash already exists in the database are silently skipped and
+ *       counted as duplicates rather than failures.</li>
+ * </ul>
+ */
 @Service
 public class CsvImportService {
 
@@ -39,10 +54,24 @@ public class CsvImportService {
         this.categoryRepository = categoryRepository;
     }
 
+    /**
+     * Imports transactions from a CSV file for the given user.
+     *
+     * <p>Each row is hashed before saving. If an identical hash already exists in the
+     * database the row is counted as a duplicate and skipped without an error entry.
+     * Parse/validation failures are captured in the {@code errors} list.
+     *
+     * @param userId            the authenticated user's id
+     * @param file              the uploaded CSV file
+     * @param defaultCategoryId optional category override; when null the first matching
+     *                          EXPENSE/INCOME category is used
+     * @return summary of the import operation
+     */
     @Transactional
     public CsvImportResult importCsv(Long userId, MultipartFile file, Long defaultCategoryId) {
         List<String> errors = new ArrayList<>();
         int importedCount = 0;
+        int skippedDuplicates = 0;
         int totalRows = 0;
 
         Map<Long, Category> categoryMap = categoryRepository.findByUserIdOrUserIdIsNull(userId)
@@ -50,7 +79,8 @@ public class CsvImportService {
                 .collect(Collectors.toMap(Category::getId, c -> c));
 
         if (defaultCategoryId != null && !categoryMap.containsKey(defaultCategoryId)) {
-            return new CsvImportResult(0, 0, 0, List.of("Default category not found: " + defaultCategoryId));
+            return new CsvImportResult(0, 0, 0, 0,
+                    List.of("Default category not found: " + defaultCategoryId));
         }
 
         Long expenseCategoryId = defaultCategoryId;
@@ -70,7 +100,7 @@ public class CsvImportService {
         }
 
         if (expenseCategoryId == null || incomeCategoryId == null) {
-            return new CsvImportResult(0, 0, 0,
+            return new CsvImportResult(0, 0, 0, 0,
                     List.of("No default categories found. Create at least one INCOME and one EXPENSE category first."));
         }
 
@@ -79,7 +109,7 @@ public class CsvImportService {
 
             String headerLine = reader.readLine();
             if (headerLine == null) {
-                return new CsvImportResult(0, 0, 0, List.of("Empty CSV file"));
+                return new CsvImportResult(0, 0, 0, 0, List.of("Empty CSV file"));
             }
 
             String line;
@@ -99,10 +129,20 @@ public class CsvImportService {
                     String description = fields[1].trim();
                     BigDecimal rawAmount = new BigDecimal(fields[2].trim().replaceAll("[\"$,]", ""));
 
+                    String hash = computeImportHash(userId, date, rawAmount, description);
+
+                    // Pre-flight duplicate check: avoids the round-trip to the DB constraint
+                    // on every row and gives a cleaner code path for the common case.
+                    if (transactionRepository.existsByImportHash(hash)) {
+                        skippedDuplicates++;
+                        continue;
+                    }
+
                     Transaction tx = new Transaction();
                     tx.setUserId(userId);
                     tx.setDate(date);
                     tx.setDescription(description);
+                    tx.setImportHash(hash);
 
                     if (rawAmount.compareTo(BigDecimal.ZERO) < 0) {
                         tx.setType(TransactionType.EXPENSE);
@@ -114,18 +154,54 @@ public class CsvImportService {
                         tx.setCategoryId(incomeCategoryId);
                     }
 
-                    transactionRepository.save(tx);
-                    importedCount++;
+                    try {
+                        transactionRepository.save(tx);
+                        importedCount++;
+                    } catch (DataIntegrityViolationException e) {
+                        // Race condition: another concurrent import saved the same hash between
+                        // our existsByImportHash check and the save. Treat it as a duplicate.
+                        skippedDuplicates++;
+                    }
                 } catch (Exception e) {
                     errors.add("Row " + totalRows + ": " + e.getMessage());
                 }
             }
         } catch (Exception e) {
-            return new CsvImportResult(totalRows, importedCount, totalRows - importedCount,
+            return new CsvImportResult(totalRows, importedCount,
+                    totalRows - importedCount - skippedDuplicates, skippedDuplicates,
                     List.of("Failed to read CSV file: " + e.getMessage()));
         }
 
-        return new CsvImportResult(totalRows, importedCount, totalRows - importedCount, errors);
+        return new CsvImportResult(
+                totalRows,
+                importedCount,
+                totalRows - importedCount - skippedDuplicates,
+                skippedDuplicates,
+                errors);
+    }
+
+    /**
+     * Computes a SHA-256 hash from the combination of userId, date, amount, and
+     * normalised description. The userId is included so that two users can import
+     * identical transactions without triggering a false duplicate.
+     *
+     * @param userId      the owning user's id
+     * @param date        transaction date
+     * @param amount      raw amount (may be negative)
+     * @param description raw description (trimmed and lower-cased internally)
+     * @return 64-character lowercase hex string
+     */
+    String computeImportHash(Long userId, LocalDate date, BigDecimal amount, String description) {
+        String input = userId + "|" + date + "|" + amount.toPlainString() + "|"
+                + description.trim().toLowerCase();
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hashBytes = digest.digest(input.getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(hashBytes);
+        } catch (NoSuchAlgorithmException e) {
+            // SHA-256 is mandated by the JVM spec — this branch is unreachable in practice.
+            throw new IllegalStateException("SHA-256 algorithm unavailable", e);
+        }
     }
 
     private LocalDate parseDate(String dateStr) {

--- a/backend/src/main/java/com/keybudget/transaction/Transaction.java
+++ b/backend/src/main/java/com/keybudget/transaction/Transaction.java
@@ -44,6 +44,14 @@ public class Transaction {
     @Column(name = "deleted_at")
     private Instant deletedAt;
 
+    /**
+     * SHA-256 fingerprint used to detect CSV import duplicates.
+     * Only populated on CSV-imported transactions; null for manually created ones.
+     * The unique partial index on this column rejects re-imports of the same row.
+     */
+    @Column(name = "import_hash", length = 64)
+    private String importHash;
+
     @PrePersist
     void prePersist() {
         this.createdAt = Instant.now();
@@ -69,6 +77,8 @@ public class Transaction {
 
     public Instant getDeletedAt() { return deletedAt; }
 
+    public String getImportHash() { return importHash; }
+
     // Setters
 
     public void setUserId(Long userId) { this.userId = userId; }
@@ -84,4 +94,6 @@ public class Transaction {
     public void setType(TransactionType type) { this.type = type; }
 
     public void setDeletedAt(Instant deletedAt) { this.deletedAt = deletedAt; }
+
+    public void setImportHash(String importHash) { this.importHash = importHash; }
 }

--- a/backend/src/main/java/com/keybudget/transaction/TransactionRepository.java
+++ b/backend/src/main/java/com/keybudget/transaction/TransactionRepository.java
@@ -105,6 +105,16 @@ public interface TransactionRepository extends JpaRepository<Transaction, Long> 
 
     boolean existsByUserIdAndCategoryId(Long userId, Long categoryId);
 
+    /**
+     * Returns {@code true} if a transaction with the given import hash already exists.
+     * Used by {@link CsvImportService} to detect duplicate CSV rows before attempting
+     * a save, avoiding unnecessary constraint-violation exceptions.
+     *
+     * @param importHash the 64-character SHA-256 hex hash to look up
+     * @return {@code true} if a matching row exists
+     */
+    boolean existsByImportHash(String importHash);
+
     @Query("SELECT t.categoryId, SUM(t.amount) FROM Transaction t " +
            "WHERE t.userId = :userId AND t.type = 'EXPENSE' " +
            "AND t.date BETWEEN :start AND :end " +

--- a/backend/src/main/java/com/keybudget/transaction/dto/CsvImportResult.java
+++ b/backend/src/main/java/com/keybudget/transaction/dto/CsvImportResult.java
@@ -2,9 +2,19 @@ package com.keybudget.transaction.dto;
 
 import java.util.List;
 
+/**
+ * Result of a CSV import operation.
+ *
+ * @param totalRows        total data rows read from the file (excluding the header)
+ * @param importedCount    rows successfully saved as new transactions
+ * @param skippedCount     rows skipped due to parse/validation errors
+ * @param skippedDuplicates rows skipped because an identical transaction was already imported
+ * @param errors           human-readable error messages, one per skipped/invalid row
+ */
 public record CsvImportResult(
         int totalRows,
         int importedCount,
         int skippedCount,
+        int skippedDuplicates,
         List<String> errors
 ) {}

--- a/backend/src/main/resources/db/migration/V4__add_import_hash.sql
+++ b/backend/src/main/resources/db/migration/V4__add_import_hash.sql
@@ -1,0 +1,10 @@
+-- V4__add_import_hash.sql
+-- Add SHA-256 import hash to transactions for CSV duplicate detection.
+-- Only CSV-imported transactions carry a hash; manually created rows remain NULL.
+-- Both PostgreSQL and H2 honour the partial index, so multiple NULLs are allowed.
+
+ALTER TABLE transactions ADD COLUMN import_hash VARCHAR(64);
+
+CREATE UNIQUE INDEX idx_transactions_import_hash
+    ON transactions (import_hash)
+    WHERE import_hash IS NOT NULL;

--- a/backend/src/test/java/com/keybudget/transaction/CsvImportServiceTest.java
+++ b/backend/src/test/java/com/keybudget/transaction/CsvImportServiceTest.java
@@ -10,13 +10,17 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.mock.web.MockMultipartFile;
 
+import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -46,22 +50,30 @@ class CsvImportServiceTest {
         return c;
     }
 
+    private List<Category> defaultCategories() {
+        return List.of(
+                buildCategory(10L, "Food", CategoryType.EXPENSE),
+                buildCategory(11L, "Salary", CategoryType.INCOME));
+    }
+
+    // ---------------------------------------------------------------------------
+    // Existing behaviour — unchanged paths
+    // ---------------------------------------------------------------------------
+
     @Test
     void importCsv_givenValidRows_importsAll() {
         String csv = "Date,Description,Amount\n2026-03-01,Grocery Store,-50.00\n2026-03-02,Salary,3000.00\n";
         MockMultipartFile file = new MockMultipartFile("file", "test.csv", "text/csv",
                 csv.getBytes(StandardCharsets.UTF_8));
 
-        when(categoryRepository.findByUserIdOrUserIdIsNull(1L))
-                .thenReturn(List.of(
-                        buildCategory(10L, "Food", CategoryType.EXPENSE),
-                        buildCategory(11L, "Salary", CategoryType.INCOME)));
+        when(categoryRepository.findByUserIdOrUserIdIsNull(1L)).thenReturn(defaultCategories());
         when(transactionRepository.save(any(Transaction.class))).thenAnswer(inv -> inv.getArgument(0));
 
         CsvImportResult result = csvImportService.importCsv(1L, file, null);
 
         assertThat(result.totalRows()).isEqualTo(2);
         assertThat(result.importedCount()).isEqualTo(2);
+        assertThat(result.skippedDuplicates()).isZero();
         assertThat(result.errors()).isEmpty();
         verify(transactionRepository, times(2)).save(any(Transaction.class));
     }
@@ -72,10 +84,7 @@ class CsvImportServiceTest {
         MockMultipartFile file = new MockMultipartFile("file", "test.csv", "text/csv",
                 csv.getBytes(StandardCharsets.UTF_8));
 
-        when(categoryRepository.findByUserIdOrUserIdIsNull(1L))
-                .thenReturn(List.of(
-                        buildCategory(10L, "Food", CategoryType.EXPENSE),
-                        buildCategory(11L, "Salary", CategoryType.INCOME)));
+        when(categoryRepository.findByUserIdOrUserIdIsNull(1L)).thenReturn(defaultCategories());
         when(transactionRepository.save(any(Transaction.class))).thenAnswer(inv -> inv.getArgument(0));
 
         csvImportService.importCsv(1L, file, null);
@@ -93,16 +102,14 @@ class CsvImportServiceTest {
         MockMultipartFile file = new MockMultipartFile("file", "test.csv", "text/csv",
                 csv.getBytes(StandardCharsets.UTF_8));
 
-        when(categoryRepository.findByUserIdOrUserIdIsNull(1L))
-                .thenReturn(List.of(
-                        buildCategory(10L, "Food", CategoryType.EXPENSE),
-                        buildCategory(11L, "Salary", CategoryType.INCOME)));
+        when(categoryRepository.findByUserIdOrUserIdIsNull(1L)).thenReturn(defaultCategories());
 
         CsvImportResult result = csvImportService.importCsv(1L, file, null);
 
         assertThat(result.totalRows()).isEqualTo(1);
         assertThat(result.importedCount()).isEqualTo(0);
         assertThat(result.skippedCount()).isEqualTo(1);
+        assertThat(result.skippedDuplicates()).isZero();
         assertThat(result.errors()).hasSize(1);
     }
 
@@ -111,10 +118,7 @@ class CsvImportServiceTest {
         MockMultipartFile file = new MockMultipartFile("file", "test.csv", "text/csv",
                 "".getBytes(StandardCharsets.UTF_8));
 
-        when(categoryRepository.findByUserIdOrUserIdIsNull(1L))
-                .thenReturn(List.of(
-                        buildCategory(10L, "Food", CategoryType.EXPENSE),
-                        buildCategory(11L, "Salary", CategoryType.INCOME)));
+        when(categoryRepository.findByUserIdOrUserIdIsNull(1L)).thenReturn(defaultCategories());
 
         CsvImportResult result = csvImportService.importCsv(1L, file, null);
 
@@ -128,10 +132,7 @@ class CsvImportServiceTest {
         MockMultipartFile file = new MockMultipartFile("file", "test.csv", "text/csv",
                 csv.getBytes(StandardCharsets.UTF_8));
 
-        when(categoryRepository.findByUserIdOrUserIdIsNull(1L))
-                .thenReturn(List.of(
-                        buildCategory(10L, "Food", CategoryType.EXPENSE),
-                        buildCategory(11L, "Salary", CategoryType.INCOME)));
+        when(categoryRepository.findByUserIdOrUserIdIsNull(1L)).thenReturn(defaultCategories());
         when(transactionRepository.save(any(Transaction.class))).thenAnswer(inv -> inv.getArgument(0));
 
         csvImportService.importCsv(1L, file, 10L);
@@ -147,14 +148,114 @@ class CsvImportServiceTest {
         MockMultipartFile file = new MockMultipartFile("file", "test.csv", "text/csv",
                 csv.getBytes(StandardCharsets.UTF_8));
 
-        when(categoryRepository.findByUserIdOrUserIdIsNull(1L))
-                .thenReturn(List.of(
-                        buildCategory(10L, "Food", CategoryType.EXPENSE),
-                        buildCategory(11L, "Salary", CategoryType.INCOME)));
+        when(categoryRepository.findByUserIdOrUserIdIsNull(1L)).thenReturn(defaultCategories());
         when(transactionRepository.save(any(Transaction.class))).thenAnswer(inv -> inv.getArgument(0));
 
         CsvImportResult result = csvImportService.importCsv(1L, file, null);
 
         assertThat(result.importedCount()).isEqualTo(1);
+    }
+
+    // ---------------------------------------------------------------------------
+    // Duplicate detection
+    // ---------------------------------------------------------------------------
+
+    @Test
+    void importCsv_givenDuplicateRow_skipsAndCountsDuplicate() {
+        // The repository reports the hash already exists — row must be skipped silently.
+        String csv = "Date,Description,Amount\n2026-03-01,Coffee,-5.50\n";
+        MockMultipartFile file = new MockMultipartFile("file", "test.csv", "text/csv",
+                csv.getBytes(StandardCharsets.UTF_8));
+
+        when(categoryRepository.findByUserIdOrUserIdIsNull(1L)).thenReturn(defaultCategories());
+        when(transactionRepository.existsByImportHash(anyString())).thenReturn(true);
+
+        CsvImportResult result = csvImportService.importCsv(1L, file, null);
+
+        assertThat(result.totalRows()).isEqualTo(1);
+        assertThat(result.importedCount()).isZero();
+        assertThat(result.skippedDuplicates()).isEqualTo(1);
+        assertThat(result.skippedCount()).isZero();
+        assertThat(result.errors()).isEmpty();
+        verify(transactionRepository, never()).save(any(Transaction.class));
+    }
+
+    @Test
+    void importCsv_givenMixedNewAndDuplicateRows_countsEachCorrectly() {
+        // Row 1 is new; row 2 is a duplicate that already exists in the database.
+        String csv = "Date,Description,Amount\n2026-03-01,Salary,3000.00\n2026-03-02,Coffee,-5.50\n";
+        MockMultipartFile file = new MockMultipartFile("file", "test.csv", "text/csv",
+                csv.getBytes(StandardCharsets.UTF_8));
+
+        when(categoryRepository.findByUserIdOrUserIdIsNull(1L)).thenReturn(defaultCategories());
+        when(transactionRepository.save(any(Transaction.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        // First hash (Salary row) is new; second hash (Coffee row) already exists.
+        when(transactionRepository.existsByImportHash(anyString()))
+                .thenReturn(false)
+                .thenReturn(true);
+
+        CsvImportResult result = csvImportService.importCsv(1L, file, null);
+
+        assertThat(result.totalRows()).isEqualTo(2);
+        assertThat(result.importedCount()).isEqualTo(1);
+        assertThat(result.skippedDuplicates()).isEqualTo(1);
+        assertThat(result.skippedCount()).isZero();
+        assertThat(result.errors()).isEmpty();
+        verify(transactionRepository, times(1)).save(any(Transaction.class));
+    }
+
+    @Test
+    void importCsv_givenRaceConditionOnSave_treatsConstraintViolationAsDuplicate() {
+        // existsByImportHash returns false (hash not present yet), but the save throws
+        // DataIntegrityViolationException because a concurrent request saved the same
+        // hash between our check and our insert.
+        String csv = "Date,Description,Amount\n2026-03-01,Coffee,-5.50\n";
+        MockMultipartFile file = new MockMultipartFile("file", "test.csv", "text/csv",
+                csv.getBytes(StandardCharsets.UTF_8));
+
+        when(categoryRepository.findByUserIdOrUserIdIsNull(1L)).thenReturn(defaultCategories());
+        when(transactionRepository.existsByImportHash(anyString())).thenReturn(false);
+        when(transactionRepository.save(any(Transaction.class)))
+                .thenThrow(new DataIntegrityViolationException("duplicate key value"));
+
+        CsvImportResult result = csvImportService.importCsv(1L, file, null);
+
+        assertThat(result.totalRows()).isEqualTo(1);
+        assertThat(result.importedCount()).isZero();
+        assertThat(result.skippedDuplicates()).isEqualTo(1);
+        assertThat(result.errors()).isEmpty();
+    }
+
+    @Test
+    void importCsv_givenSameRowImportedByDifferentUsers_hashesAreDistinct() {
+        // Two users importing identical CSV content must not collide.
+        LocalDate date = LocalDate.of(2026, 3, 1);
+        BigDecimal amount = new BigDecimal("-5.50");
+        String description = "Coffee";
+
+        String hashUser1 = csvImportService.computeImportHash(1L, date, amount, description);
+        String hashUser2 = csvImportService.computeImportHash(2L, date, amount, description);
+
+        assertThat(hashUser1).isNotEqualTo(hashUser2);
+        assertThat(hashUser1).hasSize(64);
+        assertThat(hashUser2).hasSize(64);
+    }
+
+    @Test
+    void importCsv_givenHashStampedOnTransaction_hashIsSetBeforeSave() {
+        // Verify the importHash field is populated on the entity that reaches the repository.
+        String csv = "Date,Description,Amount\n2026-03-01,Coffee,-5.50\n";
+        MockMultipartFile file = new MockMultipartFile("file", "test.csv", "text/csv",
+                csv.getBytes(StandardCharsets.UTF_8));
+
+        when(categoryRepository.findByUserIdOrUserIdIsNull(1L)).thenReturn(defaultCategories());
+        when(transactionRepository.save(any(Transaction.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        csvImportService.importCsv(1L, file, null);
+
+        ArgumentCaptor<Transaction> captor = ArgumentCaptor.forClass(Transaction.class);
+        verify(transactionRepository).save(captor.capture());
+        assertThat(captor.getValue().getImportHash()).isNotNull().hasSize(64);
     }
 }

--- a/backend/src/test/java/com/keybudget/transaction/TransactionControllerTest.java
+++ b/backend/src/test/java/com/keybudget/transaction/TransactionControllerTest.java
@@ -59,7 +59,7 @@ class TransactionControllerTest {
                 "Date,Description,Amount\n2026-03-01,Coffee,-5.50\n".getBytes(StandardCharsets.UTF_8));
 
         when(csvImportService.importCsv(eq(1L), any(), isNull()))
-                .thenReturn(new CsvImportResult(1, 1, 0, List.of()));
+                .thenReturn(new CsvImportResult(1, 1, 0, 0, List.of()));
 
         mockMvc.perform(multipart("/api/v1/transactions/import")
                         .file(file)


### PR DESCRIPTION
## What
Flyway V4 adds import_hash column. CsvImportService computes SHA-256 hash and skips duplicates.

## Why
Re-importing CSV created duplicate transactions.

## Test plan
- Import CSV, re-import same CSV, verify duplicates skipped

Closes #55