### PR TITLE
Add CSV export endpoint

### DIFF
--- a/backend/src/main/java/com/keybudget/config/SecurityConfig.java
+++ b/backend/src/main/java/com/keybudget/config/SecurityConfig.java
@@ -121,7 +121,7 @@ public class SecurityConfig {
         config.setAllowedOrigins(List.of(frontendUrl));
         config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
         config.setAllowedHeaders(List.of("Authorization", "Content-Type"));
-        config.setExposedHeaders(List.of("Set-Cookie"));
+        config.setExposedHeaders(List.of("Set-Cookie", "Content-Disposition"));
         config.setAllowCredentials(true);
         config.setMaxAge(3600L);
 

--- a/backend/src/main/java/com/keybudget/transaction/TransactionController.java
+++ b/backend/src/main/java/com/keybudget/transaction/TransactionController.java
@@ -11,13 +11,16 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
 
 import java.time.LocalDate;
 import java.time.YearMonth;
@@ -118,6 +121,43 @@ public class TransactionController {
             @RequestParam(value = "categoryId", required = false) Long defaultCategoryId) {
         Long userId = jwt.getClaim("userId");
         return ResponseEntity.ok(csvImportService.importCsv(userId, file, defaultCategoryId));
+    }
+
+    /**
+     * GET /api/v1/transactions/export?format=csv&start=2026-01-01&end=2026-03-31
+     * Streams all transactions for the authenticated user in the requested date range as a
+     * CSV file. The response is streamed directly to avoid buffering the entire dataset in
+     * memory. The {@code format} parameter is validated to only accept {@code csv}.
+     *
+     * @param start  inclusive start date (defaults to first day of current month)
+     * @param end    inclusive end date (defaults to today)
+     * @param format must be {@code csv}; any other value results in a 400
+     */
+    @GetMapping("/export")
+    public ResponseEntity<StreamingResponseBody> exportCsv(
+            @AuthenticationPrincipal Jwt jwt,
+            @RequestParam(defaultValue = "csv") String format,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate start,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate end) {
+
+        if (!"csv".equalsIgnoreCase(format)) {
+            throw new IllegalArgumentException("Unsupported export format: " + format);
+        }
+
+        Long userId = jwt.getClaim("userId");
+
+        LocalDate effectiveStart = start != null ? start : LocalDate.now().withDayOfMonth(1);
+        LocalDate effectiveEnd = end != null ? end : LocalDate.now();
+
+        String filename = "transactions_" + effectiveStart + "_" + effectiveEnd + ".csv";
+
+        StreamingResponseBody body = transactionService.exportTransactions(userId, effectiveStart, effectiveEnd);
+
+        return ResponseEntity.ok()
+                .contentType(MediaType.parseMediaType("text/csv; charset=UTF-8"))
+                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + filename + "\"")
+                .header(HttpHeaders.CACHE_CONTROL, "no-cache")
+                .body(body);
     }
 
     /**

--- a/backend/src/main/java/com/keybudget/transaction/TransactionRepository.java
+++ b/backend/src/main/java/com/keybudget/transaction/TransactionRepository.java
@@ -120,4 +120,20 @@ public interface TransactionRepository extends JpaRepository<Transaction, Long> 
            "AND t.date BETWEEN :start AND :end " +
            "GROUP BY t.categoryId")
     List<Object[]> sumExpensesByCategory(Long userId, LocalDate start, LocalDate end);
+
+    /**
+     * Returns all transactions for a user within a date range, ordered by date ascending
+     * then by id ascending. Used for deterministic CSV export output.
+     * Soft-deleted rows are excluded automatically via the {@code @SQLRestriction} on
+     * {@link Transaction}.
+     *
+     * @param userId the owning user's id
+     * @param start  inclusive start date
+     * @param end    inclusive end date
+     * @return ordered list of matching transactions
+     */
+    @Query("SELECT t FROM Transaction t WHERE t.userId = :userId " +
+           "AND t.date BETWEEN :start AND :end ORDER BY t.date ASC, t.id ASC")
+    List<Transaction> findByUserIdAndDateBetweenOrderByDateAscIdAsc(
+            Long userId, LocalDate start, LocalDate end);
 }

--- a/backend/src/main/java/com/keybudget/transaction/TransactionServiceImpl.java
+++ b/backend/src/main/java/com/keybudget/transaction/TransactionServiceImpl.java
@@ -12,8 +12,13 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
 
+import java.io.BufferedWriter;
+import java.io.OutputStreamWriter;
 import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.YearMonth;
 import java.util.List;
@@ -38,16 +43,10 @@ public class TransactionServiceImpl implements TransactionService {
     @Override
     @Transactional(readOnly = true)
     public Page<TransactionResponse> getTransactions(
-            Long userId,
-            LocalDate start,
-            LocalDate end,
-            Long categoryId,
-            TransactionType type,
-            Pageable pageable) {
+            Long userId, LocalDate start, LocalDate end,
+            Long categoryId, TransactionType type, Pageable pageable) {
 
-        // Build a lookup map for category names from the user's visible categories
         Map<Long, String> categoryNames = buildCategoryNameMap(userId);
-
         Page<Transaction> page;
 
         if (categoryId != null && type != null) {
@@ -70,7 +69,6 @@ public class TransactionServiceImpl implements TransactionService {
     @Override
     @Transactional
     public TransactionResponse createTransaction(Long userId, CreateTransactionRequest req) {
-        // Verify the category exists and is accessible to this user
         categoryRepository.findByUserIdOrUserIdIsNull(userId).stream()
                 .filter(c -> c.getId().equals(req.categoryId()))
                 .findFirst()
@@ -86,7 +84,6 @@ public class TransactionServiceImpl implements TransactionService {
         tx.setType(req.type());
 
         Transaction saved = transactionRepository.save(tx);
-
         Map<Long, String> categoryNames = buildCategoryNameMap(userId);
         return toResponse(saved, categoryNames);
     }
@@ -113,9 +110,6 @@ public class TransactionServiceImpl implements TransactionService {
 
         BigDecimal netSavings = totalIncome.subtract(totalExpenses);
 
-        // Group INCOME and EXPENSE transactions by category, summing amounts.
-        // TRANSFER transactions are deliberately excluded — they represent money moved
-        // between accounts and must not inflate category spending figures.
         Map<Long, BigDecimal> totalsMap = all.stream()
                 .filter(t -> t.getType() == TransactionType.INCOME
                         || t.getType() == TransactionType.EXPENSE)
@@ -128,8 +122,7 @@ public class TransactionServiceImpl implements TransactionService {
                 .map(e -> new CategoryTotal(
                         e.getKey(),
                         categoryNames.getOrDefault(e.getKey(), "Unknown"),
-                        e.getValue()
-                ))
+                        e.getValue()))
                 .toList();
 
         return new MonthlySummaryResponse(totalIncome, totalExpenses, netSavings, byCategory);
@@ -167,9 +160,34 @@ public class TransactionServiceImpl implements TransactionService {
         transactionRepository.save(tx);
     }
 
-    // -------------------------------------------------------------------------
-    // Private helpers
-    // -------------------------------------------------------------------------
+    /** {@inheritDoc} */
+    @Override
+    @Transactional(readOnly = true)
+    public StreamingResponseBody exportTransactions(Long userId, LocalDate start, LocalDate end) {
+        List<Transaction> transactions =
+                transactionRepository.findByUserIdAndDateBetweenOrderByDateAscIdAsc(userId, start, end);
+        Map<Long, String> categoryNames = buildCategoryNameMap(userId);
+
+        return outputStream -> {
+            try (BufferedWriter writer = new BufferedWriter(
+                    new OutputStreamWriter(outputStream, StandardCharsets.UTF_8))) {
+                // RFC 4180 requires CRLF line endings
+                writer.write("Date,Description,Amount,Category,Type\r\n");
+                for (Transaction t : transactions) {
+                    writer.write(escapeCsvField(t.getDate().toString()));
+                    writer.write(',');
+                    writer.write(escapeCsvField(t.getDescription() != null ? t.getDescription() : ""));
+                    writer.write(',');
+                    writer.write(escapeCsvField(t.getAmount().toPlainString()));
+                    writer.write(',');
+                    writer.write(escapeCsvField(categoryNames.getOrDefault(t.getCategoryId(), "Unknown")));
+                    writer.write(',');
+                    writer.write(escapeCsvField(t.getType().name()));
+                    writer.write("\r\n");
+                }
+            }
+        };
+    }
 
     private Map<Long, String> buildCategoryNameMap(Long userId) {
         return categoryRepository.findByUserIdOrUserIdIsNull(userId).stream()
@@ -184,7 +202,21 @@ public class TransactionServiceImpl implements TransactionService {
                 t.getDate(),
                 t.getType(),
                 t.getCategoryId(),
-                categoryNames.getOrDefault(t.getCategoryId(), "Unknown")
-        );
+                categoryNames.getOrDefault(t.getCategoryId(), "Unknown"));
+    }
+
+    /**
+     * Escapes a single CSV field per RFC 4180. If the value contains a comma, double-quote,
+     * or newline, it is wrapped in double-quotes and internal double-quotes are doubled.
+     *
+     * @param value the raw field value (never null)
+     * @return the escaped field ready to be written to the CSV stream
+     */
+    private String escapeCsvField(String value) {
+        if (value.indexOf(',') >= 0 || value.indexOf('"') >= 0
+                || value.indexOf('\n') >= 0 || value.indexOf('\r') >= 0) {
+            return '"' + value.replace("\"", "\"\"") + '"';
+        }
+        return value;
     }
 }

--- a/backend/src/test/java/com/keybudget/transaction/TransactionControllerTest.java
+++ b/backend/src/test/java/com/keybudget/transaction/TransactionControllerTest.java
@@ -17,7 +17,9 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 
 import java.math.BigDecimal;
@@ -338,6 +340,79 @@ class TransactionControllerTest {
                 .thenThrow(new RuntimeException("DB error"));
 
         mockMvc.perform(get("/api/v1/transactions/summary")
+                        .with(jwt().jwt(j -> j.claim("userId", 1L))))
+                .andExpect(status().isInternalServerError())
+                .andExpect(jsonPath("$.error").value("INTERNAL_ERROR"));
+    }
+
+    // -------------------------------------------------------------------------
+    // GET /api/v1/transactions/export
+    // -------------------------------------------------------------------------
+
+    @Test
+    void exportCsv_givenValidJwt_200() throws Exception {
+        String csvContent = "Date,Description,Amount,Category,Type\r\n"
+                + "2026-03-01,Coffee,5.50,Food,EXPENSE\r\n";
+
+        StreamingResponseBody streamingBody = outputStream ->
+                outputStream.write(csvContent.getBytes(StandardCharsets.UTF_8));
+
+        when(transactionService.exportTransactions(eq(1L), any(LocalDate.class), any(LocalDate.class)))
+                .thenReturn(streamingBody);
+
+        mockMvc.perform(get("/api/v1/transactions/export")
+                        .param("format", "csv")
+                        .param("start", "2026-03-01")
+                        .param("end", "2026-03-31")
+                        .with(jwt().jwt(j -> j.claim("userId", 1L))))
+                .andExpect(status().isOk())
+                .andExpect(header().string("Content-Type", "text/csv;charset=UTF-8"))
+                .andExpect(header().string("Content-Disposition",
+                        "attachment; filename=\"transactions_2026-03-01_2026-03-31.csv\""))
+                .andExpect(header().string("Cache-Control", "no-cache"))
+                .andExpect(result -> {
+                    String body = result.getResponse().getContentAsString(StandardCharsets.UTF_8);
+                    assertThat(body).startsWith("Date,Description,Amount,Category,Type");
+                    assertThat(body).contains("Coffee");
+                });
+    }
+
+    @Test
+    void exportCsv_givenDefaultDates_200() throws Exception {
+        // No start/end params supplied — service should receive month-start to today
+        StreamingResponseBody streamingBody = outputStream ->
+                outputStream.write("Date,Description,Amount,Category,Type\r\n".getBytes(StandardCharsets.UTF_8));
+
+        when(transactionService.exportTransactions(eq(1L), any(LocalDate.class), any(LocalDate.class)))
+                .thenReturn(streamingBody);
+
+        mockMvc.perform(get("/api/v1/transactions/export")
+                        .with(jwt().jwt(j -> j.claim("userId", 1L))))
+                .andExpect(status().isOk())
+                .andExpect(header().exists("Content-Disposition"));
+    }
+
+    @Test
+    void exportCsv_givenUnsupportedFormat_400() throws Exception {
+        mockMvc.perform(get("/api/v1/transactions/export")
+                        .param("format", "xlsx")
+                        .with(jwt().jwt(j -> j.claim("userId", 1L))))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void exportCsv_givenNoJwt_401() throws Exception {
+        mockMvc.perform(get("/api/v1/transactions/export"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void exportCsv_givenServiceThrows_500() throws Exception {
+        when(transactionService.exportTransactions(eq(1L), any(LocalDate.class), any(LocalDate.class)))
+                .thenThrow(new RuntimeException("DB error"));
+
+        mockMvc.perform(get("/api/v1/transactions/export")
+                        .param("format", "csv")
                         .with(jwt().jwt(j -> j.claim("userId", 1L))))
                 .andExpect(status().isInternalServerError())
                 .andExpect(jsonPath("$.error").value("INTERNAL_ERROR"));

--- a/backend/src/test/java/com/keybudget/transaction/TransactionServiceImplTest.java
+++ b/backend/src/test/java/com/keybudget/transaction/TransactionServiceImplTest.java
@@ -17,14 +17,16 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
 
+import java.io.ByteArrayOutputStream;
 import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.YearMonth;
 import java.util.List;
 import java.util.Optional;
-
-import java.time.Instant;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -334,6 +336,149 @@ class TransactionServiceImplTest {
         assertThatThrownBy(() -> transactionService.deleteTransaction(userId, 999L))
                 .isInstanceOf(ResourceNotFoundException.class)
                 .hasMessageContaining("Transaction not found");
+    }
+
+    // -------------------------------------------------------------------------
+    // exportTransactions
+    // -------------------------------------------------------------------------
+
+    @Test
+    void exportTransactions_givenTransactions_writesCsvWithHeader() throws Exception {
+        Long userId = 1L;
+        LocalDate start = LocalDate.of(2026, 3, 1);
+        LocalDate end = LocalDate.of(2026, 3, 31);
+
+        Category cat = buildCategory(5L, "Food");
+        Transaction tx = buildTransaction(10L, userId, 5L, new BigDecimal("12.50"), TransactionType.EXPENSE);
+        tx.setDescription("Lunch");
+
+        when(categoryRepository.findByUserIdOrUserIdIsNull(userId)).thenReturn(List.of(cat));
+        when(transactionRepository.findByUserIdAndDateBetweenOrderByDateAscIdAsc(userId, start, end))
+                .thenReturn(List.of(tx));
+
+        StreamingResponseBody body = transactionService.exportTransactions(userId, start, end);
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        body.writeTo(out);
+        String csv = out.toString(StandardCharsets.UTF_8);
+
+        assertThat(csv).startsWith("Date,Description,Amount,Category,Type\r\n");
+        assertThat(csv).contains("2026-03-15");
+        assertThat(csv).contains("Lunch");
+        assertThat(csv).contains("12.50");
+        assertThat(csv).contains("Food");
+        assertThat(csv).contains("EXPENSE");
+    }
+
+    @Test
+    void exportTransactions_givenNoTransactions_writesHeaderOnly() throws Exception {
+        Long userId = 1L;
+        LocalDate start = LocalDate.of(2026, 3, 1);
+        LocalDate end = LocalDate.of(2026, 3, 31);
+
+        when(categoryRepository.findByUserIdOrUserIdIsNull(userId)).thenReturn(List.of());
+        when(transactionRepository.findByUserIdAndDateBetweenOrderByDateAscIdAsc(userId, start, end))
+                .thenReturn(List.of());
+
+        StreamingResponseBody body = transactionService.exportTransactions(userId, start, end);
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        body.writeTo(out);
+        String csv = out.toString(StandardCharsets.UTF_8);
+
+        assertThat(csv).isEqualTo("Date,Description,Amount,Category,Type\r\n");
+    }
+
+    @Test
+    void exportTransactions_givenNullDescription_writesEmptyField() throws Exception {
+        Long userId = 1L;
+        LocalDate start = LocalDate.of(2026, 3, 1);
+        LocalDate end = LocalDate.of(2026, 3, 31);
+
+        Category cat = buildCategory(5L, "Food");
+        Transaction tx = buildTransaction(10L, userId, 5L, new BigDecimal("5.00"), TransactionType.EXPENSE);
+        // description is null by default from buildTransaction
+
+        when(categoryRepository.findByUserIdOrUserIdIsNull(userId)).thenReturn(List.of(cat));
+        when(transactionRepository.findByUserIdAndDateBetweenOrderByDateAscIdAsc(userId, start, end))
+                .thenReturn(List.of(tx));
+
+        StreamingResponseBody body = transactionService.exportTransactions(userId, start, end);
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        body.writeTo(out);
+        String csv = out.toString(StandardCharsets.UTF_8);
+
+        // Null description must produce an empty field, not "null"
+        assertThat(csv).contains("2026-03-15,,5.00,Food,EXPENSE");
+    }
+
+    @Test
+    void exportTransactions_givenDescriptionWithComma_quotesField() throws Exception {
+        Long userId = 1L;
+        LocalDate start = LocalDate.of(2026, 3, 1);
+        LocalDate end = LocalDate.of(2026, 3, 31);
+
+        Category cat = buildCategory(5L, "Food");
+        Transaction tx = buildTransaction(10L, userId, 5L, new BigDecimal("8.75"), TransactionType.EXPENSE);
+        tx.setDescription("Coffee, latte");
+
+        when(categoryRepository.findByUserIdOrUserIdIsNull(userId)).thenReturn(List.of(cat));
+        when(transactionRepository.findByUserIdAndDateBetweenOrderByDateAscIdAsc(userId, start, end))
+                .thenReturn(List.of(tx));
+
+        StreamingResponseBody body = transactionService.exportTransactions(userId, start, end);
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        body.writeTo(out);
+        String csv = out.toString(StandardCharsets.UTF_8);
+
+        assertThat(csv).contains("\"Coffee, latte\"");
+    }
+
+    @Test
+    void exportTransactions_givenDescriptionWithDoubleQuote_escapesQuotes() throws Exception {
+        Long userId = 1L;
+        LocalDate start = LocalDate.of(2026, 3, 1);
+        LocalDate end = LocalDate.of(2026, 3, 31);
+
+        Category cat = buildCategory(5L, "Food");
+        Transaction tx = buildTransaction(10L, userId, 5L, new BigDecimal("3.00"), TransactionType.EXPENSE);
+        tx.setDescription("Say \"hello\"");
+
+        when(categoryRepository.findByUserIdOrUserIdIsNull(userId)).thenReturn(List.of(cat));
+        when(transactionRepository.findByUserIdAndDateBetweenOrderByDateAscIdAsc(userId, start, end))
+                .thenReturn(List.of(tx));
+
+        StreamingResponseBody body = transactionService.exportTransactions(userId, start, end);
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        body.writeTo(out);
+        String csv = out.toString(StandardCharsets.UTF_8);
+
+        assertThat(csv).contains("\"Say \"\"hello\"\"\"");
+    }
+
+    @Test
+    void exportTransactions_givenUnknownCategory_writesUnknown() throws Exception {
+        Long userId = 1L;
+        LocalDate start = LocalDate.of(2026, 3, 1);
+        LocalDate end = LocalDate.of(2026, 3, 31);
+
+        Transaction tx = buildTransaction(10L, userId, 999L, new BigDecimal("20.00"), TransactionType.EXPENSE);
+        tx.setDescription("Mystery");
+
+        when(categoryRepository.findByUserIdOrUserIdIsNull(userId)).thenReturn(List.of());
+        when(transactionRepository.findByUserIdAndDateBetweenOrderByDateAscIdAsc(userId, start, end))
+                .thenReturn(List.of(tx));
+
+        StreamingResponseBody body = transactionService.exportTransactions(userId, start, end);
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        body.writeTo(out);
+        String csv = out.toString(StandardCharsets.UTF_8);
+
+        assertThat(csv).contains("Unknown");
     }
 
     // -------------------------------------------------------------------------


### PR DESCRIPTION
## What
New `GET /api/v1/transactions/export?format=csv` endpoint streams transactions as CSV with date range filtering.

## Why
Users need to export financial data for spreadsheets and external tools.

## Test plan
- [ ] Export with date range returns CSV with correct headers
- [ ] Default dates use current month
- [ ] Category names resolved (not IDs)
- [ ] CSV fields properly escaped (commas, quotes)
- [ ] Content-Disposition exposed in CORS

Closes #57

?? Generated with [Claude Code](https://claude.com/claude-code)