### PR TITLE
Fix test compilation after config extraction

### DIFF
--- a/backend/src/test/java/com/keybudget/auth/JwtServiceImplTest.java
+++ b/backend/src/test/java/com/keybudget/auth/JwtServiceImplTest.java
@@ -47,7 +47,8 @@ class JwtServiceImplTest {
 
     @BeforeEach
     void setUp() throws Exception {
-        jwtService = new JwtServiceImpl(PRIVATE_KEY_BASE64, PUBLIC_KEY_BASE64, ISSUER, AUDIENCE);
+        // refreshTokenMaxAge: 7 days in seconds (matches prod default)
+        jwtService = new JwtServiceImpl(PRIVATE_KEY_BASE64, PUBLIC_KEY_BASE64, ISSUER, AUDIENCE, 604800L);
     }
 
     private User buildUser(Long id) {

--- a/backend/src/test/java/com/keybudget/budget/BudgetServiceImplTest.java
+++ b/backend/src/test/java/com/keybudget/budget/BudgetServiceImplTest.java
@@ -166,7 +166,7 @@ class BudgetServiceImplTest {
         Budget revived = buildBudget(10L, userId, 5L, month, new BigDecimal("400.00"));
 
         when(categoryRepository.findByUserIdOrUserIdIsNull(userId)).thenReturn(List.of(cat));
-        when(budgetRepository.findSoftDeletedByUserIdAndCategoryIdAndMonthYear(userId, 5L, month))
+        when(budgetRepository.findSoftDeletedByUserIdAndCategoryIdAndMonthYear(userId, 5L, month.toString()))
                 .thenReturn(Optional.of(softDeleted));
         when(budgetRepository.save(softDeleted)).thenReturn(revived);
         when(transactionRepository.sumExpensesByCategory(eq(userId), any(LocalDate.class), any(LocalDate.class)))

--- a/backend/src/test/resources/application.properties
+++ b/backend/src/test/resources/application.properties
@@ -27,3 +27,6 @@ spring.flyway.enabled=false
 
 # Required by AuthController — secure flag must be false in test (no HTTPS)
 app.cookie.secure=false
+
+# Required by AuthController + JwtServiceImpl — 7 days in seconds
+app.refresh-token.max-age-seconds=604800


### PR DESCRIPTION
## Summary
- Add missing `refreshTokenMaxAge` constructor param to JwtServiceImplTest
- Fix BudgetServiceImplTest stub to pass String instead of YearMonth
- Add `app.refresh-token.max-age-seconds` to test application.properties

## Test plan
- [x] All 232 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)