### PR TITLE
Fix V4 migration for H2 compatibility

### DIFF
--- a/backend/src/main/resources/db/migration/V4__add_import_hash.sql
+++ b/backend/src/main/resources/db/migration/V4__add_import_hash.sql
@@ -1,10 +1,10 @@
 -- V4__add_import_hash.sql
 -- Add SHA-256 import hash to transactions for CSV duplicate detection.
 -- Only CSV-imported transactions carry a hash; manually created rows remain NULL.
--- Both PostgreSQL and H2 honour the partial index, so multiple NULLs are allowed.
+-- Both PostgreSQL and H2 treat NULLs as distinct in unique indexes,
+-- so multiple NULL rows are allowed without a partial index.
 
 ALTER TABLE transactions ADD COLUMN import_hash VARCHAR(64);
 
 CREATE UNIQUE INDEX idx_transactions_import_hash
-    ON transactions (import_hash)
-    WHERE import_hash IS NOT NULL;
+    ON transactions (import_hash);


### PR DESCRIPTION
## Summary
- Remove partial index WHERE clause from V4 migration - H2 does not support it
- Both H2 and PostgreSQL treat NULLs as distinct in unique indexes

## Test plan
- [ ] Backend starts with H2 dev profile
- [ ] All tests pass