### PR TITLE
Fix OAuth2 login by allowing sessions for auth flow

### DIFF
--- a/backend/src/main/java/com/keybudget/config/SecurityConfig.java
+++ b/backend/src/main/java/com/keybudget/config/SecurityConfig.java
@@ -57,7 +57,7 @@ public class SecurityConfig {
         http
             .cors(cors -> cors.configurationSource(corsConfigurationSource()))
             .csrf(csrf -> csrf.disable())
-            .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+            .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED))
             .headers(headers -> headers
                 .contentTypeOptions(ct -> {}) // X-Content-Type-Options: nosniff
                 .frameOptions(fo -> fo.deny()) // X-Frame-Options: DENY


### PR DESCRIPTION
## Summary
- Change session policy from STATELESS to IF_REQUIRED
- STATELESS prevented Spring from storing OAuth2 authorization request between redirect and callback
- API endpoints remain stateless via JWT bearer tokens

## Test plan
- [x] Google OAuth login completes successfully
- [x] JWT-protected API endpoints still work without sessions