### PR TITLE
Add Plaid Link integration for M1 Finance and Marcus

### DIFF
--- a/backend/src/main/java/com/keybudget/integration/IntegrationController.java
+++ b/backend/src/main/java/com/keybudget/integration/IntegrationController.java
@@ -13,7 +13,6 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
-import java.util.Set;
 
 /** REST endpoints for financial provider integrations and net-worth queries. */
 @Validated
@@ -21,11 +20,7 @@ import java.util.Set;
 @RequestMapping("/api/v1/integrations")
 public class IntegrationController {
 
-    /** Providers that may be connected through the Plaid Link flow. */
-    private static final Set<ProviderType> PLAID_PROVIDERS = Set.of(
-            ProviderType.M1_FINANCE,
-            ProviderType.MARCUS
-    );
+    private static final String PLAID_ACCESS_TOKEN_KEY = "plaidAccessToken";
 
     private final IntegrationOrchestrationService orchestrationService;
     private final PlaidService plaidService;
@@ -138,13 +133,8 @@ public class IntegrationController {
             @AuthenticationPrincipal Jwt jwt,
             @RequestParam ProviderType provider) {
 
-        if (!PLAID_PROVIDERS.contains(provider)) {
-            throw new IllegalArgumentException(
-                    "Provider " + provider + " does not support Plaid Link. "
-                    + "Supported providers: M1_FINANCE, MARCUS");
-        }
-
         Long userId = jwt.getClaim("userId");
+        // PlaidService validates that provider is Plaid-backed; throws IllegalArgumentException if not
         PlaidService.PlaidLinkTokenResult result = plaidService.createLinkToken(userId, provider);
         return ResponseEntity.ok(new PlaidLinkTokenResponse(result.linkToken(), result.expiration()));
     }
@@ -168,11 +158,11 @@ public class IntegrationController {
         Long userId = jwt.getClaim("userId");
 
         PlaidService.PlaidAccessTokenResult tokenResult =
-                plaidService.exchangePublicToken(request.publicToken());
+                plaidService.exchangePublicToken(request.publicToken(), request.provider());
 
         ConnectAccountRequest connectRequest = new ConnectAccountRequest(
                 request.provider(),
-                java.util.Map.of("plaidAccessToken", tokenResult.accessToken())
+                java.util.Map.of(PLAID_ACCESS_TOKEN_KEY, tokenResult.accessToken())
         );
 
         List<AccountResponse> accounts = orchestrationService.connectProvider(userId, connectRequest);

--- a/backend/src/main/java/com/keybudget/integration/IntegrationController.java
+++ b/backend/src/main/java/com/keybudget/integration/IntegrationController.java
@@ -1,6 +1,7 @@
 package com.keybudget.integration;
 
 import com.keybudget.integration.dto.*;
+import com.keybudget.integration.provider.plaid.PlaidService;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
@@ -12,6 +13,7 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.Set;
 
 /** REST endpoints for financial provider integrations and net-worth queries. */
 @Validated
@@ -19,10 +21,20 @@ import java.util.List;
 @RequestMapping("/api/v1/integrations")
 public class IntegrationController {
 
-    private final IntegrationOrchestrationService orchestrationService;
+    /** Providers that may be connected through the Plaid Link flow. */
+    private static final Set<ProviderType> PLAID_PROVIDERS = Set.of(
+            ProviderType.M1_FINANCE,
+            ProviderType.MARCUS
+    );
 
-    public IntegrationController(IntegrationOrchestrationService orchestrationService) {
+    private final IntegrationOrchestrationService orchestrationService;
+    private final PlaidService plaidService;
+
+    public IntegrationController(
+            IntegrationOrchestrationService orchestrationService,
+            PlaidService plaidService) {
         this.orchestrationService = orchestrationService;
+        this.plaidService = plaidService;
     }
 
     /**
@@ -108,5 +120,62 @@ public class IntegrationController {
             @RequestParam(defaultValue = "30") @Min(1) @Max(365) int days) {
         Long userId = jwt.getClaim("userId");
         return ResponseEntity.ok(orchestrationService.getNetWorthHistory(userId, days));
+    }
+
+    /**
+     * POST /api/v1/integrations/plaid/link-token?provider=M1_FINANCE
+     *
+     * <p>Creates a Plaid Link token for the authenticated user and the specified provider.
+     * The frontend passes this token to the Plaid Link SDK to open the institution-connection
+     * UI. Only {@code M1_FINANCE} and {@code MARCUS} are accepted; any other value returns 400.
+     *
+     * @param jwt      the authenticated user's JWT
+     * @param provider the target provider; must be {@code M1_FINANCE} or {@code MARCUS}
+     * @return 200 with a {@link PlaidLinkTokenResponse} on success, 400 if provider is invalid
+     */
+    @PostMapping("/plaid/link-token")
+    public ResponseEntity<PlaidLinkTokenResponse> createPlaidLinkToken(
+            @AuthenticationPrincipal Jwt jwt,
+            @RequestParam ProviderType provider) {
+
+        if (!PLAID_PROVIDERS.contains(provider)) {
+            throw new IllegalArgumentException(
+                    "Provider " + provider + " does not support Plaid Link. "
+                    + "Supported providers: M1_FINANCE, MARCUS");
+        }
+
+        Long userId = jwt.getClaim("userId");
+        PlaidService.PlaidLinkTokenResult result = plaidService.createLinkToken(userId, provider);
+        return ResponseEntity.ok(new PlaidLinkTokenResponse(result.linkToken(), result.expiration()));
+    }
+
+    /**
+     * POST /api/v1/integrations/plaid/exchange
+     *
+     * <p>Exchanges the short-lived Plaid public token (returned by the frontend Link SDK after
+     * the user connects their institution) for a permanent access token, then delegates to
+     * the standard connect flow to persist the credential and discover accounts.
+     *
+     * @param jwt     the authenticated user's JWT
+     * @param request contains the public token and the provider that was connected
+     * @return 201 with the list of discovered and persisted accounts
+     */
+    @PostMapping("/plaid/exchange")
+    public ResponseEntity<List<AccountResponse>> exchangePlaidPublicToken(
+            @AuthenticationPrincipal Jwt jwt,
+            @Valid @RequestBody PlaidExchangeRequest request) {
+
+        Long userId = jwt.getClaim("userId");
+
+        PlaidService.PlaidAccessTokenResult tokenResult =
+                plaidService.exchangePublicToken(request.publicToken());
+
+        ConnectAccountRequest connectRequest = new ConnectAccountRequest(
+                request.provider(),
+                java.util.Map.of("plaidAccessToken", tokenResult.accessToken())
+        );
+
+        List<AccountResponse> accounts = orchestrationService.connectProvider(userId, connectRequest);
+        return ResponseEntity.status(HttpStatus.CREATED).body(accounts);
     }
 }

--- a/backend/src/main/java/com/keybudget/integration/dto/PlaidExchangeRequest.java
+++ b/backend/src/main/java/com/keybudget/integration/dto/PlaidExchangeRequest.java
@@ -3,6 +3,7 @@ package com.keybudget.integration.dto;
 import com.keybudget.integration.ProviderType;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 
 /**
  * Request payload for {@code POST /api/v1/integrations/plaid/exchange}.
@@ -17,6 +18,8 @@ import jakarta.validation.constraints.NotNull;
 public record PlaidExchangeRequest(
 
         @NotBlank(message = "publicToken must not be blank")
+        @Pattern(regexp = "^public-(sandbox|development|production)-[a-f0-9\\-]{36}$",
+                message = "publicToken must be a valid Plaid public token")
         String publicToken,
 
         @NotNull(message = "provider is required")

--- a/backend/src/main/java/com/keybudget/integration/dto/PlaidExchangeRequest.java
+++ b/backend/src/main/java/com/keybudget/integration/dto/PlaidExchangeRequest.java
@@ -1,0 +1,24 @@
+package com.keybudget.integration.dto;
+
+import com.keybudget.integration.ProviderType;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * Request payload for {@code POST /api/v1/integrations/plaid/exchange}.
+ *
+ * <p>After the user completes the Plaid Link flow, the frontend receives a short-lived
+ * public token and must immediately POST it here (along with which provider was connected)
+ * so the backend can exchange it for a permanent access token and complete the integration.
+ *
+ * @param publicToken the short-lived public token returned by the Plaid Link SDK
+ * @param provider    the provider that was connected via Plaid Link (e.g., {@code M1_FINANCE})
+ */
+public record PlaidExchangeRequest(
+
+        @NotBlank(message = "publicToken must not be blank")
+        String publicToken,
+
+        @NotNull(message = "provider is required")
+        ProviderType provider
+) {}

--- a/backend/src/main/java/com/keybudget/integration/dto/PlaidLinkTokenResponse.java
+++ b/backend/src/main/java/com/keybudget/integration/dto/PlaidLinkTokenResponse.java
@@ -1,0 +1,13 @@
+package com.keybudget.integration.dto;
+
+/**
+ * API response DTO returned by {@code POST /api/v1/integrations/plaid/link-token}.
+ *
+ * <p>The frontend passes {@code linkToken} directly to the Plaid Link SDK to open the
+ * institution-connection UI. The {@code expiration} field is informational; the frontend
+ * should complete the Link flow before this timestamp.
+ *
+ * @param linkToken  opaque Plaid link token for the frontend SDK
+ * @param expiration ISO-8601 timestamp at which the link token expires (typically 30 minutes)
+ */
+public record PlaidLinkTokenResponse(String linkToken, String expiration) {}

--- a/backend/src/main/java/com/keybudget/integration/provider/plaid/PlaidService.java
+++ b/backend/src/main/java/com/keybudget/integration/provider/plaid/PlaidService.java
@@ -42,7 +42,7 @@ public interface PlaidService {
      * @return a {@link PlaidAccessTokenResult} containing the permanent access token and Item ID
      * @throws ProviderException if the Plaid API rejects the public token or is unreachable
      */
-    PlaidAccessTokenResult exchangePublicToken(String publicToken);
+    PlaidAccessTokenResult exchangePublicToken(String publicToken, ProviderType provider);
 
     /**
      * Result of a successful Plaid link-token creation.

--- a/backend/src/main/java/com/keybudget/integration/provider/plaid/PlaidService.java
+++ b/backend/src/main/java/com/keybudget/integration/provider/plaid/PlaidService.java
@@ -1,0 +1,62 @@
+package com.keybudget.integration.provider.plaid;
+
+import com.keybudget.integration.ProviderType;
+import com.keybudget.integration.exception.ProviderException;
+
+/**
+ * Service contract for Plaid API interactions used by the Plaid Link flow.
+ *
+ * <p>Implementations are responsible for calling the Plaid REST API directly via WebClient.
+ * The Plaid Java SDK is intentionally not used to keep the dependency surface minimal and
+ * to remain in full control of HTTP error handling and timeout behaviour.
+ */
+public interface PlaidService {
+
+    /**
+     * Creates a Plaid Link token for the given user and provider combination.
+     *
+     * <p>The link token is a short-lived (30-minute) opaque token that the frontend
+     * Plaid Link SDK uses to open the institution-connection UI. Each provider maps to
+     * a distinct set of Plaid products:
+     * <ul>
+     *   <li>{@code M1_FINANCE} → {@code ["investments"]}</li>
+     *   <li>{@code MARCUS}     → {@code ["auth", "transactions"]}</li>
+     * </ul>
+     *
+     * @param userId   the authenticated user's database ID (used as Plaid's client_user_id)
+     * @param provider the provider being connected; must be a Plaid-backed provider
+     * @return a {@link PlaidLinkTokenResult} containing the link token and its expiration timestamp
+     * @throws IllegalArgumentException if {@code provider} is not a Plaid-backed provider
+     * @throws ProviderException        if the Plaid API returns an error or is unreachable
+     */
+    PlaidLinkTokenResult createLinkToken(Long userId, ProviderType provider);
+
+    /**
+     * Exchanges a short-lived Plaid public token (returned by the frontend Link SDK)
+     * for a permanent access token.
+     *
+     * <p>The returned access token must be stored encrypted and used for all subsequent
+     * Plaid API calls for this Item (user + institution link).
+     *
+     * @param publicToken the public token received from the Plaid Link SDK on the frontend
+     * @return a {@link PlaidAccessTokenResult} containing the permanent access token and Item ID
+     * @throws ProviderException if the Plaid API rejects the public token or is unreachable
+     */
+    PlaidAccessTokenResult exchangePublicToken(String publicToken);
+
+    /**
+     * Result of a successful Plaid link-token creation.
+     *
+     * @param linkToken  opaque token to pass to the Plaid Link SDK on the frontend
+     * @param expiration ISO-8601 timestamp at which the link token expires
+     */
+    record PlaidLinkTokenResult(String linkToken, String expiration) {}
+
+    /**
+     * Result of a successful public-token exchange.
+     *
+     * @param accessToken permanent Plaid access token to be stored encrypted
+     * @param itemId      Plaid Item ID — stable identifier for this user's institution link
+     */
+    record PlaidAccessTokenResult(String accessToken, String itemId) {}
+}

--- a/backend/src/main/java/com/keybudget/integration/provider/plaid/PlaidServiceImpl.java
+++ b/backend/src/main/java/com/keybudget/integration/provider/plaid/PlaidServiceImpl.java
@@ -1,0 +1,237 @@
+package com.keybudget.integration.provider.plaid;
+
+import com.keybudget.integration.ProviderType;
+import com.keybudget.integration.exception.ProviderAuthException;
+import com.keybudget.integration.exception.ProviderException;
+import com.keybudget.integration.exception.ProviderRateLimitException;
+import com.keybudget.integration.provider.plaid.config.PlaidConfig;
+import com.keybudget.integration.provider.plaid.dto.PlaidLinkTokenCreateRequest;
+import com.keybudget.integration.provider.plaid.dto.PlaidLinkTokenCreateResponse;
+import com.keybudget.integration.provider.plaid.dto.PlaidPublicTokenExchangeRequest;
+import com.keybudget.integration.provider.plaid.dto.PlaidPublicTokenExchangeResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+import reactor.core.publisher.Mono;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * WebClient-based implementation of {@link PlaidService}.
+ *
+ * <p>All Plaid API calls are made synchronously (via {@code .block()}) with a 10-second
+ * timeout to fit the existing blocking provider model. HTTP 400/401 from Plaid are mapped
+ * to {@link ProviderAuthException}; HTTP 429 maps to {@link ProviderRateLimitException};
+ * all other errors map to {@link ProviderException}.
+ */
+@Slf4j
+@Service
+public class PlaidServiceImpl implements PlaidService {
+
+    private static final Duration API_TIMEOUT = Duration.ofSeconds(10);
+
+    /**
+     * Plaid-backed providers that are valid targets for link-token creation.
+     * Any provider not in this set will be rejected at the service layer.
+     */
+    private static final Set<ProviderType> PLAID_PROVIDERS = Set.of(
+            ProviderType.M1_FINANCE,
+            ProviderType.MARCUS
+    );
+
+    private final WebClient plaidClient;
+    private final PlaidConfig plaidConfig;
+
+    /**
+     * Constructs a {@code PlaidServiceImpl} with a provider-specific WebClient.
+     *
+     * @param webClientBuilder pre-configured builder from {@link com.keybudget.config.WebClientConfig}
+     * @param plaidConfig      Plaid credentials and environment configuration
+     */
+    public PlaidServiceImpl(WebClient.Builder webClientBuilder, PlaidConfig plaidConfig) {
+        this.plaidConfig = plaidConfig;
+        this.plaidClient = webClientBuilder.clone()
+                .baseUrl(plaidConfig.getEffectiveBaseUrl())
+                .defaultHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                .build();
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>Products are selected based on the provider:
+     * <ul>
+     *   <li>{@code M1_FINANCE} uses {@code investments}</li>
+     *   <li>{@code MARCUS} uses {@code auth} and {@code transactions}</li>
+     * </ul>
+     */
+    @Override
+    public PlaidLinkTokenResult createLinkToken(Long userId, ProviderType provider) {
+        if (!PLAID_PROVIDERS.contains(provider)) {
+            throw new IllegalArgumentException(
+                    "Provider " + provider + " is not a Plaid-backed provider. "
+                    + "Supported: " + PLAID_PROVIDERS);
+        }
+
+        List<String> products = resolveProducts(provider);
+
+        PlaidLinkTokenCreateRequest requestBody = new PlaidLinkTokenCreateRequest(
+                plaidConfig.getClientId(),
+                plaidConfig.getSecret(),
+                "KeyBudget",
+                new PlaidLinkTokenCreateRequest.PlaidUser(String.valueOf(userId)),
+                products,
+                List.of("US"),
+                "en"
+        );
+
+        log.info("Creating Plaid link token for userId={}, provider={}, products={}",
+                userId, provider, products);
+
+        PlaidLinkTokenCreateResponse response = plaidClient.post()
+                .uri("/link/token/create")
+                .bodyValue(requestBody)
+                .retrieve()
+                .onStatus(this::isUnauthorized, httpResponse ->
+                        Mono.error(new ProviderAuthException(
+                                provider,
+                                "Plaid rejected credentials — check PLAID_CLIENT_ID and PLAID_SECRET")))
+                .onStatus(this::isRateLimit, httpResponse ->
+                        Mono.error(new ProviderRateLimitException(
+                                provider, "Plaid API rate limit exceeded on /link/token/create")))
+                .onStatus(HttpStatusCode::is4xxClientError, httpResponse ->
+                        Mono.error(new ProviderException(
+                                provider,
+                                "Plaid returned client error on /link/token/create: HTTP "
+                                        + httpResponse.statusCode().value())))
+                .onStatus(HttpStatusCode::is5xxServerError, httpResponse ->
+                        Mono.error(new ProviderException(
+                                provider,
+                                "Plaid returned server error on /link/token/create: HTTP "
+                                        + httpResponse.statusCode().value())))
+                .bodyToMono(PlaidLinkTokenCreateResponse.class)
+                .timeout(API_TIMEOUT)
+                .doOnError(ex -> log.error(
+                        "Plaid /link/token/create failed for userId={}, provider={}: {}",
+                        userId, provider, ex.getMessage()))
+                .onErrorMap(ex -> wrapNonProviderException(provider).apply(ex))
+                .block();
+
+        if (response == null || response.linkToken() == null) {
+            throw new ProviderException(provider, "Plaid returned an empty link token response");
+        }
+
+        log.info("Plaid link token created for userId={}, provider={}, expiration={}",
+                userId, provider, response.expiration());
+
+        return new PlaidLinkTokenResult(response.linkToken(), response.expiration());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public PlaidAccessTokenResult exchangePublicToken(String publicToken) {
+        PlaidPublicTokenExchangeRequest requestBody = new PlaidPublicTokenExchangeRequest(
+                plaidConfig.getClientId(),
+                plaidConfig.getSecret(),
+                publicToken
+        );
+
+        log.info("Exchanging Plaid public token for permanent access token");
+
+        PlaidPublicTokenExchangeResponse response = plaidClient.post()
+                .uri("/item/public_token/exchange")
+                .bodyValue(requestBody)
+                .retrieve()
+                .onStatus(this::isUnauthorized, httpResponse ->
+                        Mono.error(new ProviderAuthException(
+                                ProviderType.M1_FINANCE,
+                                "Plaid rejected the public token — it may have expired or already been exchanged")))
+                .onStatus(this::isRateLimit, httpResponse ->
+                        Mono.error(new ProviderRateLimitException(
+                                ProviderType.M1_FINANCE,
+                                "Plaid API rate limit exceeded on /item/public_token/exchange")))
+                .onStatus(HttpStatusCode::is4xxClientError, httpResponse ->
+                        Mono.error(new ProviderException(
+                                ProviderType.M1_FINANCE,
+                                "Plaid returned client error on /item/public_token/exchange: HTTP "
+                                        + httpResponse.statusCode().value())))
+                .onStatus(HttpStatusCode::is5xxServerError, httpResponse ->
+                        Mono.error(new ProviderException(
+                                ProviderType.M1_FINANCE,
+                                "Plaid returned server error on /item/public_token/exchange: HTTP "
+                                        + httpResponse.statusCode().value())))
+                .bodyToMono(PlaidPublicTokenExchangeResponse.class)
+                .timeout(API_TIMEOUT)
+                .doOnError(ex -> log.error(
+                        "Plaid /item/public_token/exchange failed: {}", ex.getMessage()))
+                .onErrorMap(ex -> wrapNonProviderException(ProviderType.M1_FINANCE).apply(ex))
+                .block();
+
+        if (response == null || response.accessToken() == null) {
+            throw new ProviderException(ProviderType.M1_FINANCE,
+                    "Plaid returned an empty token exchange response");
+        }
+
+        log.info("Plaid public token exchanged successfully, itemId={}", response.itemId());
+
+        return new PlaidAccessTokenResult(response.accessToken(), response.itemId());
+    }
+
+    // -------------------------------------------------------------------------
+    // Private helpers
+    // -------------------------------------------------------------------------
+
+    /**
+     * Maps a provider type to the appropriate Plaid products list.
+     *
+     * @param provider the Plaid-backed provider
+     * @return list of Plaid product names
+     */
+    private List<String> resolveProducts(ProviderType provider) {
+        return switch (provider) {
+            case M1_FINANCE -> List.of("investments");
+            case MARCUS     -> List.of("auth", "transactions");
+            default -> throw new IllegalArgumentException(
+                    "No product mapping for provider: " + provider);
+        };
+    }
+
+    /**
+     * Returns a function that wraps non-{@link ProviderException} throwables into a
+     * {@link ProviderException}, leaving existing {@code ProviderException} subclasses
+     * unchanged so {@code onErrorMap} does not re-wrap already-mapped errors.
+     *
+     * @param provider the provider context for the wrapped exception
+     * @return a mapping function suitable for {@code Mono.onErrorMap}
+     */
+    private java.util.function.Function<Throwable, Throwable> wrapNonProviderException(
+            ProviderType provider) {
+        return ex -> {
+            if (ex instanceof ProviderException) {
+                return ex;
+            }
+            if (ex instanceof WebClientResponseException wcEx) {
+                return new ProviderException(provider,
+                        "Plaid API error: " + wcEx.getMessage(), wcEx);
+            }
+            return new ProviderException(provider,
+                    "Failed to reach Plaid API: " + ex.getMessage(), ex);
+        };
+    }
+
+    private boolean isUnauthorized(HttpStatusCode status) {
+        return status == HttpStatus.UNAUTHORIZED || status == HttpStatus.FORBIDDEN;
+    }
+
+    private boolean isRateLimit(HttpStatusCode status) {
+        return status == HttpStatus.TOO_MANY_REQUESTS;
+    }
+}

--- a/backend/src/main/java/com/keybudget/integration/provider/plaid/PlaidServiceImpl.java
+++ b/backend/src/main/java/com/keybudget/integration/provider/plaid/PlaidServiceImpl.java
@@ -137,7 +137,7 @@ public class PlaidServiceImpl implements PlaidService {
      * {@inheritDoc}
      */
     @Override
-    public PlaidAccessTokenResult exchangePublicToken(String publicToken) {
+    public PlaidAccessTokenResult exchangePublicToken(String publicToken, ProviderType provider) {
         PlaidPublicTokenExchangeRequest requestBody = new PlaidPublicTokenExchangeRequest(
                 plaidConfig.getClientId(),
                 plaidConfig.getSecret(),
@@ -152,31 +152,31 @@ public class PlaidServiceImpl implements PlaidService {
                 .retrieve()
                 .onStatus(this::isUnauthorized, httpResponse ->
                         Mono.error(new ProviderAuthException(
-                                ProviderType.M1_FINANCE,
+                                provider,
                                 "Plaid rejected the public token — it may have expired or already been exchanged")))
                 .onStatus(this::isRateLimit, httpResponse ->
                         Mono.error(new ProviderRateLimitException(
-                                ProviderType.M1_FINANCE,
+                                provider,
                                 "Plaid API rate limit exceeded on /item/public_token/exchange")))
                 .onStatus(HttpStatusCode::is4xxClientError, httpResponse ->
                         Mono.error(new ProviderException(
-                                ProviderType.M1_FINANCE,
+                                provider,
                                 "Plaid returned client error on /item/public_token/exchange: HTTP "
                                         + httpResponse.statusCode().value())))
                 .onStatus(HttpStatusCode::is5xxServerError, httpResponse ->
                         Mono.error(new ProviderException(
-                                ProviderType.M1_FINANCE,
+                                provider,
                                 "Plaid returned server error on /item/public_token/exchange: HTTP "
                                         + httpResponse.statusCode().value())))
                 .bodyToMono(PlaidPublicTokenExchangeResponse.class)
                 .timeout(API_TIMEOUT)
                 .doOnError(ex -> log.error(
                         "Plaid /item/public_token/exchange failed: {}", ex.getMessage()))
-                .onErrorMap(ex -> wrapNonProviderException(ProviderType.M1_FINANCE).apply(ex))
+                .onErrorMap(ex -> wrapNonProviderException(provider).apply(ex))
                 .block();
 
         if (response == null || response.accessToken() == null) {
-            throw new ProviderException(ProviderType.M1_FINANCE,
+            throw new ProviderException(provider,
                     "Plaid returned an empty token exchange response");
         }
 

--- a/backend/src/main/java/com/keybudget/integration/provider/plaid/PlaidServiceImpl.java
+++ b/backend/src/main/java/com/keybudget/integration/provider/plaid/PlaidServiceImpl.java
@@ -119,7 +119,7 @@ public class PlaidServiceImpl implements PlaidService {
                 .timeout(API_TIMEOUT)
                 .doOnError(ex -> log.error(
                         "Plaid /link/token/create failed for userId={}, provider={}: {}",
-                        userId, provider, ex.getMessage()))
+                        userId, provider, sanitizeErrorMessage(ex)))
                 .onErrorMap(ex -> wrapNonProviderException(provider).apply(ex))
                 .block();
 
@@ -171,7 +171,7 @@ public class PlaidServiceImpl implements PlaidService {
                 .bodyToMono(PlaidPublicTokenExchangeResponse.class)
                 .timeout(API_TIMEOUT)
                 .doOnError(ex -> log.error(
-                        "Plaid /item/public_token/exchange failed: {}", ex.getMessage()))
+                        "Plaid /item/public_token/exchange failed: {}", sanitizeErrorMessage(ex)))
                 .onErrorMap(ex -> wrapNonProviderException(provider).apply(ex))
                 .block();
 
@@ -220,10 +220,10 @@ public class PlaidServiceImpl implements PlaidService {
             }
             if (ex instanceof WebClientResponseException wcEx) {
                 return new ProviderException(provider,
-                        "Plaid API error: " + wcEx.getMessage(), wcEx);
+                        "Plaid API error: HTTP " + wcEx.getStatusCode().value(), wcEx);
             }
             return new ProviderException(provider,
-                    "Failed to reach Plaid API: " + ex.getMessage(), ex);
+                    "Failed to reach Plaid API: " + ex.getClass().getSimpleName(), ex);
         };
     }
 
@@ -233,5 +233,19 @@ public class PlaidServiceImpl implements PlaidService {
 
     private boolean isRateLimit(HttpStatusCode status) {
         return status == HttpStatus.TOO_MANY_REQUESTS;
+    }
+
+    /**
+     * Extracts a safe error description that never includes HTTP response bodies
+     * (which may echo back Plaid credentials).
+     */
+    private String sanitizeErrorMessage(Throwable ex) {
+        if (ex instanceof WebClientResponseException wcEx) {
+            return "HTTP " + wcEx.getStatusCode().value();
+        }
+        if (ex instanceof ProviderException) {
+            return ex.getMessage();
+        }
+        return ex.getClass().getSimpleName();
     }
 }

--- a/backend/src/main/java/com/keybudget/integration/provider/plaid/config/PlaidConfig.java
+++ b/backend/src/main/java/com/keybudget/integration/provider/plaid/config/PlaidConfig.java
@@ -1,0 +1,72 @@
+package com.keybudget.integration.provider.plaid.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Externalized configuration for the Plaid integration.
+ * Properties are bound from the {@code integration.plaid} prefix.
+ *
+ * <p>The {@link #getBaseUrl()} method derives the Plaid API base URL from the
+ * configured {@code env} value, so callers never need to hard-code environment-specific URLs.
+ * Setting {@code integration.plaid.base-url} explicitly in properties overrides the derived URL.
+ */
+@Configuration
+@ConfigurationProperties(prefix = "integration.plaid")
+@Getter
+@Setter
+public class PlaidConfig {
+
+    /**
+     * Plaid client ID from the Plaid Dashboard.
+     * Sourced from the {@code PLAID_CLIENT_ID} environment variable.
+     */
+    private String clientId;
+
+    /**
+     * Plaid secret key for the configured environment.
+     * Sourced from the {@code PLAID_SECRET} environment variable.
+     */
+    private String secret;
+
+    /**
+     * Plaid environment: {@code sandbox}, {@code development}, or {@code production}.
+     * Defaults to {@code sandbox}.
+     */
+    private String env = "sandbox";
+
+    /**
+     * Optional explicit base URL. When set, this value takes precedence over the URL
+     * derived from {@link #env}. Set {@code integration.plaid.base-url} in properties
+     * to pin to a specific URL without changing the env label.
+     */
+    private String baseUrl;
+
+    /**
+     * Returns the effective Plaid API base URL.
+     * If {@code baseUrl} is set explicitly, that value is returned as-is.
+     * Otherwise the URL is derived from {@code env}:
+     * <ul>
+     *   <li>{@code sandbox}     → {@code https://sandbox.plaid.com}</li>
+     *   <li>{@code development} → {@code https://development.plaid.com}</li>
+     *   <li>{@code production}  → {@code https://production.plaid.com}</li>
+     * </ul>
+     *
+     * @return the base URL to use for all Plaid API calls
+     * @throws IllegalStateException if {@code env} is not one of the recognised values
+     */
+    public String getEffectiveBaseUrl() {
+        if (baseUrl != null && !baseUrl.isBlank()) {
+            return baseUrl;
+        }
+        return switch (env) {
+            case "sandbox"     -> "https://sandbox.plaid.com";
+            case "development" -> "https://development.plaid.com";
+            case "production"  -> "https://production.plaid.com";
+            default -> throw new IllegalStateException(
+                    "Unknown Plaid env: '" + env + "'. Must be sandbox, development, or production.");
+        };
+    }
+}

--- a/backend/src/main/java/com/keybudget/integration/provider/plaid/dto/PlaidLinkTokenCreateRequest.java
+++ b/backend/src/main/java/com/keybudget/integration/provider/plaid/dto/PlaidLinkTokenCreateRequest.java
@@ -1,0 +1,36 @@
+package com.keybudget.integration.provider.plaid.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+/**
+ * Wire-format request body for the Plaid {@code POST /link/token/create} endpoint.
+ *
+ * @param clientId     Plaid client ID
+ * @param secret       Plaid secret for the target environment
+ * @param clientName   application name shown in the Plaid Link UI
+ * @param userId       user object identifying the end-user in Plaid
+ * @param products     list of Plaid products to request (e.g., {@code investments}, {@code auth})
+ * @param countryCodes ISO-3166-1 alpha-2 country codes (e.g., {@code ["US"]})
+ * @param language     IETF language tag for the Plaid Link UI (e.g., {@code "en"})
+ */
+public record PlaidLinkTokenCreateRequest(
+        @JsonProperty("client_id")   String clientId,
+        @JsonProperty("secret")      String secret,
+        @JsonProperty("client_name") String clientName,
+        @JsonProperty("user")        PlaidUser userId,
+        @JsonProperty("products")    List<String> products,
+        @JsonProperty("country_codes") List<String> countryCodes,
+        @JsonProperty("language")    String language
+) {
+
+    /**
+     * Plaid user object embedded in the link-token create request.
+     *
+     * @param clientUserId a stable, unique identifier for the end-user in the calling application
+     */
+    public record PlaidUser(
+            @JsonProperty("client_user_id") String clientUserId
+    ) {}
+}

--- a/backend/src/main/java/com/keybudget/integration/provider/plaid/dto/PlaidLinkTokenCreateResponse.java
+++ b/backend/src/main/java/com/keybudget/integration/provider/plaid/dto/PlaidLinkTokenCreateResponse.java
@@ -1,0 +1,16 @@
+package com.keybudget.integration.provider.plaid.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Wire-format response from the Plaid {@code POST /link/token/create} endpoint.
+ *
+ * @param linkToken  opaque token passed to the Plaid Link SDK on the frontend
+ * @param expiration ISO-8601 expiration timestamp for the link token (typically 30 minutes)
+ * @param requestId  Plaid request ID for support/debugging
+ */
+public record PlaidLinkTokenCreateResponse(
+        @JsonProperty("link_token")  String linkToken,
+        @JsonProperty("expiration")  String expiration,
+        @JsonProperty("request_id") String requestId
+) {}

--- a/backend/src/main/java/com/keybudget/integration/provider/plaid/dto/PlaidPublicTokenExchangeRequest.java
+++ b/backend/src/main/java/com/keybudget/integration/provider/plaid/dto/PlaidPublicTokenExchangeRequest.java
@@ -1,0 +1,16 @@
+package com.keybudget.integration.provider.plaid.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Wire-format request body for the Plaid {@code POST /item/public_token/exchange} endpoint.
+ *
+ * @param clientId    Plaid client ID
+ * @param secret      Plaid secret for the target environment
+ * @param publicToken the short-lived public token returned by Plaid Link on the frontend
+ */
+public record PlaidPublicTokenExchangeRequest(
+        @JsonProperty("client_id")    String clientId,
+        @JsonProperty("secret")       String secret,
+        @JsonProperty("public_token") String publicToken
+) {}

--- a/backend/src/main/java/com/keybudget/integration/provider/plaid/dto/PlaidPublicTokenExchangeResponse.java
+++ b/backend/src/main/java/com/keybudget/integration/provider/plaid/dto/PlaidPublicTokenExchangeResponse.java
@@ -1,0 +1,16 @@
+package com.keybudget.integration.provider.plaid.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Wire-format response from the Plaid {@code POST /item/public_token/exchange} endpoint.
+ *
+ * @param accessToken permanent access token stored encrypted for future API calls
+ * @param itemId      Plaid Item ID — the stable identifier for this user's institution link
+ * @param requestId   Plaid request ID for support/debugging
+ */
+public record PlaidPublicTokenExchangeResponse(
+        @JsonProperty("access_token") String accessToken,
+        @JsonProperty("item_id")      String itemId,
+        @JsonProperty("request_id")   String requestId
+) {}

--- a/backend/src/main/resources/application-dev.properties
+++ b/backend/src/main/resources/application-dev.properties
@@ -67,8 +67,6 @@ integration.coinbase.api-version=2024-01-01
 # Set PLAID_CLIENT_ID and PLAID_SECRET env vars from your Plaid dashboard
 integration.plaid.client-id=${PLAID_CLIENT_ID:not-configured}
 integration.plaid.secret=${PLAID_SECRET:not-configured}
-# env drives URL derivation: sandbox | development | production
-integration.plaid.env=sandbox
-# Explicit base URL — overrides env-derived URL when set.
-# Keep as sandbox.plaid.com for local dev; switch to development.plaid.com for real institution data.
-integration.plaid.base-url=https://sandbox.plaid.com
+# env drives URL: sandbox | development | production
+# Use 'development' with production secret for real data (free, up to 5 Items)
+integration.plaid.env=development

--- a/backend/src/main/resources/application-dev.properties
+++ b/backend/src/main/resources/application-dev.properties
@@ -67,4 +67,8 @@ integration.coinbase.api-version=2024-01-01
 # Set PLAID_CLIENT_ID and PLAID_SECRET env vars from your Plaid dashboard
 integration.plaid.client-id=${PLAID_CLIENT_ID:not-configured}
 integration.plaid.secret=${PLAID_SECRET:not-configured}
+# env drives URL derivation: sandbox | development | production
 integration.plaid.env=sandbox
+# Explicit base URL — overrides env-derived URL when set.
+# Keep as sandbox.plaid.com for local dev; switch to development.plaid.com for real institution data.
+integration.plaid.base-url=https://sandbox.plaid.com

--- a/backend/src/test/java/com/keybudget/integration/IntegrationControllerPlaidTest.java
+++ b/backend/src/test/java/com/keybudget/integration/IntegrationControllerPlaidTest.java
@@ -1,0 +1,425 @@
+package com.keybudget.integration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.keybudget.integration.dto.AccountResponse;
+import com.keybudget.integration.dto.ConnectAccountRequest;
+import com.keybudget.integration.dto.PlaidExchangeRequest;
+import com.keybudget.integration.exception.ProviderAuthException;
+import com.keybudget.integration.exception.ProviderException;
+import com.keybudget.integration.exception.ProviderRateLimitException;
+import com.keybudget.integration.provider.plaid.PlaidService;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Slice tests for the Plaid-specific endpoints added to {@link IntegrationController}:
+ * <ul>
+ *   <li>{@code POST /api/v1/integrations/plaid/link-token}</li>
+ *   <li>{@code POST /api/v1/integrations/plaid/exchange}</li>
+ * </ul>
+ *
+ * Covers 200/201, 400, 401, 429, 500, 502, and unauthenticated 401 scenarios.
+ * {@link IntegrationOrchestrationService} and {@link PlaidService} are both mocked;
+ * no real Plaid API calls are made.
+ *
+ * <p>Valid Plaid public tokens must match the pattern:
+ * {@code ^public-(sandbox|development|production)-[a-f0-9\-]{36}$}
+ * — a UUID-like 36-character hex-plus-dash string after the environment prefix.
+ */
+@WebMvcTest(IntegrationController.class)
+class IntegrationControllerPlaidTest {
+
+    private static final long USER_ID = 42L;
+
+    /**
+     * A valid public token matching {@code ^public-sandbox-[a-f0-9\-]{36}$}.
+     * Uses a real UUID-format hex string for the suffix.
+     */
+    private static final String VALID_PUBLIC_TOKEN =
+            "public-sandbox-a1b2c3d4-e5f6-7890-abcd-ef1234567890";
+
+    @Autowired private MockMvc mockMvc;
+    @Autowired private ObjectMapper objectMapper;
+
+    @MockBean private IntegrationOrchestrationService orchestrationService;
+    @MockBean private PlaidService plaidService;
+
+    // =========================================================================
+    // POST /api/v1/integrations/plaid/link-token
+    // =========================================================================
+
+    @Nested
+    class CreatePlaidLinkToken {
+
+        @Test
+        void createPlaidLinkToken_givenM1Finance_200() throws Exception {
+            when(plaidService.createLinkToken(USER_ID, ProviderType.M1_FINANCE))
+                    .thenReturn(new PlaidService.PlaidLinkTokenResult(
+                            "link-sandbox-abc123", "2026-03-09T12:30:00Z"));
+
+            mockMvc.perform(post("/api/v1/integrations/plaid/link-token")
+                            .param("provider", "M1_FINANCE")
+                            .with(jwt().jwt(j -> j.claim("userId", USER_ID)))
+                            .with(csrf()))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.linkToken").value("link-sandbox-abc123"))
+                    .andExpect(jsonPath("$.expiration").value("2026-03-09T12:30:00Z"));
+        }
+
+        @Test
+        void createPlaidLinkToken_givenMarcus_200() throws Exception {
+            when(plaidService.createLinkToken(USER_ID, ProviderType.MARCUS))
+                    .thenReturn(new PlaidService.PlaidLinkTokenResult(
+                            "link-sandbox-marcus456", "2026-03-09T12:30:00Z"));
+
+            mockMvc.perform(post("/api/v1/integrations/plaid/link-token")
+                            .param("provider", "MARCUS")
+                            .with(jwt().jwt(j -> j.claim("userId", USER_ID)))
+                            .with(csrf()))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.linkToken").value("link-sandbox-marcus456"));
+        }
+
+        @Test
+        void createPlaidLinkToken_givenNonPlaidProvider_400() throws Exception {
+            // The service layer throws IllegalArgumentException for non-Plaid providers;
+            // GlobalExceptionHandler maps that to 400 BAD_REQUEST.
+            when(plaidService.createLinkToken(USER_ID, ProviderType.BITCOIN_WALLET))
+                    .thenThrow(new IllegalArgumentException(
+                            "Provider BITCOIN_WALLET is not a Plaid-backed provider"));
+
+            mockMvc.perform(post("/api/v1/integrations/plaid/link-token")
+                            .param("provider", "BITCOIN_WALLET")
+                            .with(jwt().jwt(j -> j.claim("userId", USER_ID)))
+                            .with(csrf()))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.error").value("BAD_REQUEST"));
+        }
+
+        @Test
+        void createPlaidLinkToken_givenMissingProvider_500() throws Exception {
+            // Spring's MissingServletRequestParameterException is not handled by
+            // GlobalExceptionHandler, so it falls through to the generic 500 handler.
+            mockMvc.perform(post("/api/v1/integrations/plaid/link-token")
+                            .with(jwt().jwt(j -> j.claim("userId", USER_ID)))
+                            .with(csrf()))
+                    .andExpect(status().isInternalServerError());
+        }
+
+        @Test
+        void createPlaidLinkToken_givenInvalidProviderValue_500() throws Exception {
+            // MethodArgumentTypeMismatchException (enum conversion failure) is not handled
+            // by GlobalExceptionHandler — falls through to generic 500 handler.
+            mockMvc.perform(post("/api/v1/integrations/plaid/link-token")
+                            .param("provider", "UNKNOWN_BANK")
+                            .with(jwt().jwt(j -> j.claim("userId", USER_ID)))
+                            .with(csrf()))
+                    .andExpect(status().isInternalServerError());
+        }
+
+        @Test
+        void createPlaidLinkToken_givenNoJwt_401() throws Exception {
+            mockMvc.perform(post("/api/v1/integrations/plaid/link-token")
+                            .param("provider", "M1_FINANCE")
+                            .with(csrf()))
+                    .andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        void createPlaidLinkToken_givenPlaidCredentialRejected_401() throws Exception {
+            when(plaidService.createLinkToken(USER_ID, ProviderType.M1_FINANCE))
+                    .thenThrow(new ProviderAuthException(
+                            ProviderType.M1_FINANCE,
+                            "Plaid rejected credentials — check PLAID_CLIENT_ID and PLAID_SECRET"));
+
+            mockMvc.perform(post("/api/v1/integrations/plaid/link-token")
+                            .param("provider", "M1_FINANCE")
+                            .with(jwt().jwt(j -> j.claim("userId", USER_ID)))
+                            .with(csrf()))
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(jsonPath("$.error").value("PROVIDER_AUTH_ERROR"));
+        }
+
+        @Test
+        void createPlaidLinkToken_givenPlaidRateLimit_429() throws Exception {
+            when(plaidService.createLinkToken(USER_ID, ProviderType.M1_FINANCE))
+                    .thenThrow(new ProviderRateLimitException(
+                            ProviderType.M1_FINANCE,
+                            "Plaid API rate limit exceeded on /link/token/create"));
+
+            mockMvc.perform(post("/api/v1/integrations/plaid/link-token")
+                            .param("provider", "M1_FINANCE")
+                            .with(jwt().jwt(j -> j.claim("userId", USER_ID)))
+                            .with(csrf()))
+                    .andExpect(status().isTooManyRequests())
+                    .andExpect(jsonPath("$.error").value("PROVIDER_RATE_LIMIT"));
+        }
+
+        @Test
+        void createPlaidLinkToken_givenPlaidServerError_502() throws Exception {
+            when(plaidService.createLinkToken(USER_ID, ProviderType.M1_FINANCE))
+                    .thenThrow(new ProviderException(
+                            ProviderType.M1_FINANCE,
+                            "Plaid returned server error on /link/token/create: HTTP 503"));
+
+            mockMvc.perform(post("/api/v1/integrations/plaid/link-token")
+                            .param("provider", "M1_FINANCE")
+                            .with(jwt().jwt(j -> j.claim("userId", USER_ID)))
+                            .with(csrf()))
+                    .andExpect(status().isBadGateway())
+                    .andExpect(jsonPath("$.error").value("PROVIDER_ERROR"));
+        }
+    }
+
+    // =========================================================================
+    // POST /api/v1/integrations/plaid/exchange
+    // =========================================================================
+
+    @Nested
+    class ExchangePlaidPublicToken {
+
+        private AccountResponse buildAccountResponse(ProviderType provider) {
+            return new AccountResponse(
+                    1L, 10L, provider, AccountType.BROKERAGE,
+                    "M1 Finance Account", "USD",
+                    new BigDecimal("10000.00"), new BigDecimal("10000.00"),
+                    Instant.now(), true
+            );
+        }
+
+        @Test
+        void exchangePlaidPublicToken_givenValidM1Request_201() throws Exception {
+            PlaidExchangeRequest request =
+                    new PlaidExchangeRequest(VALID_PUBLIC_TOKEN, ProviderType.M1_FINANCE);
+
+            when(plaidService.exchangePublicToken(VALID_PUBLIC_TOKEN, ProviderType.M1_FINANCE))
+                    .thenReturn(new PlaidService.PlaidAccessTokenResult(
+                            "access-sandbox-perm456", "item-sandbox-789"));
+
+            when(orchestrationService.connectProvider(eq(USER_ID), any(ConnectAccountRequest.class)))
+                    .thenReturn(List.of(buildAccountResponse(ProviderType.M1_FINANCE)));
+
+            mockMvc.perform(post("/api/v1/integrations/plaid/exchange")
+                            .with(jwt().jwt(j -> j.claim("userId", USER_ID)))
+                            .with(csrf())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$[0].providerType").value("M1_FINANCE"))
+                    .andExpect(jsonPath("$[0].active").value(true));
+        }
+
+        @Test
+        void exchangePlaidPublicToken_givenValidMarcusRequest_201() throws Exception {
+            String marcusToken = "public-sandbox-b2c3d4e5-f6a7-8901-bcde-f12345678901";
+            PlaidExchangeRequest request =
+                    new PlaidExchangeRequest(marcusToken, ProviderType.MARCUS);
+
+            when(plaidService.exchangePublicToken(marcusToken, ProviderType.MARCUS))
+                    .thenReturn(new PlaidService.PlaidAccessTokenResult(
+                            "access-sandbox-marcus-perm", "item-marcus-777"));
+
+            when(orchestrationService.connectProvider(eq(USER_ID), any(ConnectAccountRequest.class)))
+                    .thenReturn(List.of(buildAccountResponse(ProviderType.MARCUS)));
+
+            mockMvc.perform(post("/api/v1/integrations/plaid/exchange")
+                            .with(jwt().jwt(j -> j.claim("userId", USER_ID)))
+                            .with(csrf())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$[0].providerType").value("MARCUS"));
+        }
+
+        @Test
+        void exchangePlaidPublicToken_givenMissingPublicToken_400() throws Exception {
+            // publicToken is @NotBlank — omitting it triggers MethodArgumentNotValidException
+            String bodyWithoutPublicToken = objectMapper.writeValueAsString(
+                    Map.of("provider", "M1_FINANCE"));
+
+            mockMvc.perform(post("/api/v1/integrations/plaid/exchange")
+                            .with(jwt().jwt(j -> j.claim("userId", USER_ID)))
+                            .with(csrf())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(bodyWithoutPublicToken))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.error").value("VALIDATION_ERROR"));
+        }
+
+        @Test
+        void exchangePlaidPublicToken_givenBlankPublicToken_400() throws Exception {
+            // Blank value fails @NotBlank before @Pattern is evaluated
+            String body = "{\"publicToken\":\"   \",\"provider\":\"M1_FINANCE\"}";
+
+            mockMvc.perform(post("/api/v1/integrations/plaid/exchange")
+                            .with(jwt().jwt(j -> j.claim("userId", USER_ID)))
+                            .with(csrf())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(body))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.error").value("VALIDATION_ERROR"));
+        }
+
+        @Test
+        void exchangePlaidPublicToken_givenInvalidPublicTokenFormat_400() throws Exception {
+            // Fails the @Pattern constraint — not a valid Plaid token format
+            String body = "{\"publicToken\":\"not-a-valid-plaid-token\",\"provider\":\"M1_FINANCE\"}";
+
+            mockMvc.perform(post("/api/v1/integrations/plaid/exchange")
+                            .with(jwt().jwt(j -> j.claim("userId", USER_ID)))
+                            .with(csrf())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(body))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.error").value("VALIDATION_ERROR"));
+        }
+
+        @Test
+        void exchangePlaidPublicToken_givenMissingProvider_400() throws Exception {
+            // provider is @NotNull — omitting it triggers MethodArgumentNotValidException
+            String bodyWithoutProvider = objectMapper.writeValueAsString(
+                    Map.of("publicToken", VALID_PUBLIC_TOKEN));
+
+            mockMvc.perform(post("/api/v1/integrations/plaid/exchange")
+                            .with(jwt().jwt(j -> j.claim("userId", USER_ID)))
+                            .with(csrf())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(bodyWithoutProvider))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.error").value("VALIDATION_ERROR"));
+        }
+
+        @Test
+        void exchangePlaidPublicToken_givenNoJwt_401() throws Exception {
+            PlaidExchangeRequest request =
+                    new PlaidExchangeRequest(VALID_PUBLIC_TOKEN, ProviderType.M1_FINANCE);
+
+            mockMvc.perform(post("/api/v1/integrations/plaid/exchange")
+                            .with(csrf())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        void exchangePlaidPublicToken_givenExpiredPublicToken_401() throws Exception {
+            // Use a token format that passes validation but Plaid rejects as expired
+            String expiredToken = "public-sandbox-dead0000-0000-0000-0000-000000000000";
+            PlaidExchangeRequest request =
+                    new PlaidExchangeRequest(expiredToken, ProviderType.M1_FINANCE);
+
+            when(plaidService.exchangePublicToken(anyString(), eq(ProviderType.M1_FINANCE)))
+                    .thenThrow(new ProviderAuthException(
+                            ProviderType.M1_FINANCE,
+                            "Plaid rejected the public token — it may have expired or already been exchanged"));
+
+            mockMvc.perform(post("/api/v1/integrations/plaid/exchange")
+                            .with(jwt().jwt(j -> j.claim("userId", USER_ID)))
+                            .with(csrf())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(jsonPath("$.error").value("PROVIDER_AUTH_ERROR"));
+        }
+
+        @Test
+        void exchangePlaidPublicToken_givenPlaidRateLimit_429() throws Exception {
+            PlaidExchangeRequest request =
+                    new PlaidExchangeRequest(VALID_PUBLIC_TOKEN, ProviderType.M1_FINANCE);
+
+            when(plaidService.exchangePublicToken(anyString(), eq(ProviderType.M1_FINANCE)))
+                    .thenThrow(new ProviderRateLimitException(
+                            ProviderType.M1_FINANCE,
+                            "Plaid API rate limit exceeded on /item/public_token/exchange"));
+
+            mockMvc.perform(post("/api/v1/integrations/plaid/exchange")
+                            .with(jwt().jwt(j -> j.claim("userId", USER_ID)))
+                            .with(csrf())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isTooManyRequests())
+                    .andExpect(jsonPath("$.error").value("PROVIDER_RATE_LIMIT"));
+        }
+
+        @Test
+        void exchangePlaidPublicToken_givenPlaidServerError_502() throws Exception {
+            PlaidExchangeRequest request =
+                    new PlaidExchangeRequest(VALID_PUBLIC_TOKEN, ProviderType.M1_FINANCE);
+
+            when(plaidService.exchangePublicToken(anyString(), eq(ProviderType.M1_FINANCE)))
+                    .thenThrow(new ProviderException(
+                            ProviderType.M1_FINANCE,
+                            "Plaid returned server error on /item/public_token/exchange: HTTP 503"));
+
+            mockMvc.perform(post("/api/v1/integrations/plaid/exchange")
+                            .with(jwt().jwt(j -> j.claim("userId", USER_ID)))
+                            .with(csrf())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isBadGateway())
+                    .andExpect(jsonPath("$.error").value("PROVIDER_ERROR"));
+        }
+
+        @Test
+        void exchangePlaidPublicToken_givenAlreadyConnected_400() throws Exception {
+            PlaidExchangeRequest request =
+                    new PlaidExchangeRequest(VALID_PUBLIC_TOKEN, ProviderType.M1_FINANCE);
+
+            when(plaidService.exchangePublicToken(anyString(), eq(ProviderType.M1_FINANCE)))
+                    .thenReturn(new PlaidService.PlaidAccessTokenResult(
+                            "access-sandbox-perm456", "item-sandbox-789"));
+
+            when(orchestrationService.connectProvider(eq(USER_ID), any(ConnectAccountRequest.class)))
+                    .thenThrow(new IllegalArgumentException("Provider already connected: M1_FINANCE"));
+
+            mockMvc.perform(post("/api/v1/integrations/plaid/exchange")
+                            .with(jwt().jwt(j -> j.claim("userId", USER_ID)))
+                            .with(csrf())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.error").value("BAD_REQUEST"));
+        }
+
+        @Test
+        void exchangePlaidPublicToken_givenOrchestrationServiceThrows_500() throws Exception {
+            PlaidExchangeRequest request =
+                    new PlaidExchangeRequest(VALID_PUBLIC_TOKEN, ProviderType.M1_FINANCE);
+
+            when(plaidService.exchangePublicToken(anyString(), eq(ProviderType.M1_FINANCE)))
+                    .thenReturn(new PlaidService.PlaidAccessTokenResult(
+                            "access-sandbox-perm456", "item-sandbox-789"));
+
+            when(orchestrationService.connectProvider(eq(USER_ID), any(ConnectAccountRequest.class)))
+                    .thenThrow(new RuntimeException("Database connection lost"));
+
+            mockMvc.perform(post("/api/v1/integrations/plaid/exchange")
+                            .with(jwt().jwt(j -> j.claim("userId", USER_ID)))
+                            .with(csrf())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isInternalServerError())
+                    .andExpect(jsonPath("$.error").value("INTERNAL_ERROR"));
+        }
+    }
+}

--- a/backend/src/test/java/com/keybudget/integration/IntegrationControllerTest.java
+++ b/backend/src/test/java/com/keybudget/integration/IntegrationControllerTest.java
@@ -39,6 +39,9 @@ class IntegrationControllerTest {
     @MockBean
     private IntegrationOrchestrationService orchestrationService;
 
+    @MockBean
+    private com.keybudget.integration.provider.plaid.PlaidService plaidService;
+
     // -------------------------------------------------------------------------
     // POST /api/v1/integrations/connect
     // -------------------------------------------------------------------------

--- a/backend/src/test/java/com/keybudget/integration/provider/plaid/PlaidServiceImplTest.java
+++ b/backend/src/test/java/com/keybudget/integration/provider/plaid/PlaidServiceImplTest.java
@@ -1,0 +1,369 @@
+package com.keybudget.integration.provider.plaid;
+
+import com.keybudget.integration.ProviderType;
+import com.keybudget.integration.exception.ProviderAuthException;
+import com.keybudget.integration.exception.ProviderException;
+import com.keybudget.integration.exception.ProviderRateLimitException;
+import com.keybudget.integration.provider.plaid.config.PlaidConfig;
+import com.keybudget.integration.provider.plaid.dto.PlaidLinkTokenCreateResponse;
+import com.keybudget.integration.provider.plaid.dto.PlaidPublicTokenExchangeResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link PlaidServiceImpl}.
+ *
+ * <p>WebClient is mocked via its builder/chain so no real HTTP calls are made.
+ * The builder's {@code clone()} is stubbed to return itself, mirroring the pattern
+ * used in {@link com.keybudget.integration.provider.bitcoin.BitcoinWalletProviderTest}.
+ */
+@ExtendWith(MockitoExtension.class)
+class PlaidServiceImplTest {
+
+    private static final long   USER_ID      = 42L;
+    private static final String PUBLIC_TOKEN = "public-sandbox-abc123";
+    private static final String LINK_TOKEN   = "link-sandbox-xyz789";
+    private static final String ACCESS_TOKEN = "access-sandbox-perm456";
+    private static final String ITEM_ID      = "item-sandbox-item789";
+    private static final String EXPIRATION   = "2026-03-09T12:30:00Z";
+
+    // --- WebClient mock hierarchy --------------------------------------------
+    @Mock private WebClient.Builder         webClientBuilder;
+    @Mock private WebClient                 plaidWebClient;
+    @Mock private WebClient.RequestBodyUriSpec  requestBodyUriSpec;
+    @Mock private WebClient.RequestBodySpec     requestBodySpec;
+    @Mock private WebClient.RequestHeadersSpec<?> requestHeadersSpec;
+    @Mock private WebClient.ResponseSpec        responseSpec;
+
+    private PlaidServiceImpl service;
+
+    @BeforeEach
+    @SuppressWarnings("unchecked")
+    void setUp() {
+        when(webClientBuilder.clone()).thenReturn(webClientBuilder);
+        when(webClientBuilder.baseUrl(anyString())).thenReturn(webClientBuilder);
+        when(webClientBuilder.defaultHeader(anyString(), anyString())).thenReturn(webClientBuilder);
+        when(webClientBuilder.build()).thenReturn(plaidWebClient);
+
+        PlaidConfig config = new PlaidConfig();
+        config.setClientId("test-client-id");
+        config.setSecret("test-secret");
+        config.setBaseUrl("https://sandbox.plaid.com");
+
+        service = new PlaidServiceImpl(webClientBuilder, config);
+    }
+
+    // -------------------------------------------------------------------------
+    // createLinkToken()
+    // -------------------------------------------------------------------------
+
+    @Nested
+    class CreateLinkToken {
+
+        @Test
+        @SuppressWarnings("unchecked")
+        void createLinkToken_givenM1Finance_returnsLinkTokenResult() {
+            stubPlaidPost(new PlaidLinkTokenCreateResponse(LINK_TOKEN, EXPIRATION, "req-1"));
+
+            PlaidService.PlaidLinkTokenResult result =
+                    service.createLinkToken(USER_ID, ProviderType.M1_FINANCE);
+
+            assertThat(result.linkToken()).isEqualTo(LINK_TOKEN);
+            assertThat(result.expiration()).isEqualTo(EXPIRATION);
+        }
+
+        @Test
+        @SuppressWarnings("unchecked")
+        void createLinkToken_givenMarcus_returnsLinkTokenResult() {
+            stubPlaidPost(new PlaidLinkTokenCreateResponse(LINK_TOKEN, EXPIRATION, "req-2"));
+
+            PlaidService.PlaidLinkTokenResult result =
+                    service.createLinkToken(USER_ID, ProviderType.MARCUS);
+
+            assertThat(result.linkToken()).isEqualTo(LINK_TOKEN);
+            assertThat(result.expiration()).isEqualTo(EXPIRATION);
+        }
+
+        @Test
+        void createLinkToken_givenNonPlaidProvider_throwsIllegalArgument() {
+            assertThatThrownBy(() -> service.createLinkToken(USER_ID, ProviderType.BITCOIN_WALLET))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("not a Plaid-backed provider");
+        }
+
+        @Test
+        void createLinkToken_givenCoinbaseProvider_throwsIllegalArgument() {
+            assertThatThrownBy(() -> service.createLinkToken(USER_ID, ProviderType.COINBASE))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("not a Plaid-backed provider");
+        }
+
+        @Test
+        @SuppressWarnings("unchecked")
+        void createLinkToken_givenPlaidCredentialRejected_throwsProviderAuthException() {
+            // Simulate what the real onStatus(401/403) handler emits: ProviderAuthException.
+            // Throwing it directly from bodyToMono bypasses wrapNonProviderException because
+            // ProviderAuthException is already a ProviderException subclass.
+            stubPlaidPostError(new ProviderAuthException(
+                    ProviderType.M1_FINANCE,
+                    "Plaid rejected credentials — check PLAID_CLIENT_ID and PLAID_SECRET"));
+
+            assertThatThrownBy(() -> service.createLinkToken(USER_ID, ProviderType.M1_FINANCE))
+                    .isInstanceOf(ProviderAuthException.class);
+        }
+
+        @Test
+        @SuppressWarnings("unchecked")
+        void createLinkToken_givenPlaidRateLimit_throwsProviderRateLimitException() {
+            // Simulate what the real onStatus(429) handler emits: ProviderRateLimitException.
+            stubPlaidPostError(new ProviderRateLimitException(
+                    ProviderType.M1_FINANCE,
+                    "Plaid API rate limit exceeded on /link/token/create"));
+
+            assertThatThrownBy(() -> service.createLinkToken(USER_ID, ProviderType.M1_FINANCE))
+                    .isInstanceOf(ProviderRateLimitException.class);
+        }
+
+        @Test
+        @SuppressWarnings("unchecked")
+        void createLinkToken_givenPlaid4xxClientError_throwsProviderException() {
+            // Simulate what the real onStatus(4xx) handler emits for non-401/429 codes.
+            stubPlaidPostError(new ProviderException(
+                    ProviderType.M1_FINANCE,
+                    "Plaid returned client error on /link/token/create: HTTP 400"));
+
+            assertThatThrownBy(() -> service.createLinkToken(USER_ID, ProviderType.M1_FINANCE))
+                    .isInstanceOf(ProviderException.class)
+                    .hasMessageContaining("client error");
+        }
+
+        @Test
+        @SuppressWarnings("unchecked")
+        void createLinkToken_givenPlaid5xxServerError_throwsProviderException() {
+            // Simulate what the real onStatus(5xx) handler emits.
+            stubPlaidPostError(new ProviderException(
+                    ProviderType.M1_FINANCE,
+                    "Plaid returned server error on /link/token/create: HTTP 503"));
+
+            assertThatThrownBy(() -> service.createLinkToken(USER_ID, ProviderType.M1_FINANCE))
+                    .isInstanceOf(ProviderException.class)
+                    .hasMessageContaining("server error");
+        }
+
+        @Test
+        @SuppressWarnings("unchecked")
+        void createLinkToken_givenNetworkFailure_throwsProviderException() {
+            // Non-ProviderException throwables are caught by wrapNonProviderException
+            // and wrapped into a ProviderException with "Failed to reach Plaid API".
+            stubPlaidPostError(new java.net.ConnectException("Connection refused"));
+
+            assertThatThrownBy(() -> service.createLinkToken(USER_ID, ProviderType.M1_FINANCE))
+                    .isInstanceOf(ProviderException.class)
+                    .hasMessageContaining("Failed to reach Plaid API");
+        }
+
+        @Test
+        @SuppressWarnings("unchecked")
+        void createLinkToken_givenNullLinkTokenInResponse_throwsProviderException() {
+            // Plaid returns HTTP 200 but with a null link_token field
+            stubPlaidPost(new PlaidLinkTokenCreateResponse(null, EXPIRATION, "req-null"));
+
+            assertThatThrownBy(() -> service.createLinkToken(USER_ID, ProviderType.M1_FINANCE))
+                    .isInstanceOf(ProviderException.class)
+                    .hasMessageContaining("empty link token");
+        }
+
+        @Test
+        @SuppressWarnings("unchecked")
+        void createLinkToken_givenNullResponse_throwsProviderException() {
+            stubPlaidPostNull(PlaidLinkTokenCreateResponse.class);
+
+            assertThatThrownBy(() -> service.createLinkToken(USER_ID, ProviderType.M1_FINANCE))
+                    .isInstanceOf(ProviderException.class)
+                    .hasMessageContaining("empty link token");
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // exchangePublicToken()
+    // -------------------------------------------------------------------------
+
+    @Nested
+    class ExchangePublicToken {
+
+        @Test
+        @SuppressWarnings("unchecked")
+        void exchangePublicToken_givenValidPublicToken_returnsAccessTokenResult() {
+            stubPlaidPost(new PlaidPublicTokenExchangeResponse(ACCESS_TOKEN, ITEM_ID, "req-3"));
+
+            PlaidService.PlaidAccessTokenResult result =
+                    service.exchangePublicToken(PUBLIC_TOKEN, ProviderType.M1_FINANCE);
+
+            assertThat(result.accessToken()).isEqualTo(ACCESS_TOKEN);
+            assertThat(result.itemId()).isEqualTo(ITEM_ID);
+        }
+
+        @Test
+        @SuppressWarnings("unchecked")
+        void exchangePublicToken_givenMarcusProvider_returnsAccessTokenResult() {
+            stubPlaidPost(new PlaidPublicTokenExchangeResponse(ACCESS_TOKEN, ITEM_ID, "req-4"));
+
+            PlaidService.PlaidAccessTokenResult result =
+                    service.exchangePublicToken(PUBLIC_TOKEN, ProviderType.MARCUS);
+
+            assertThat(result.accessToken()).isEqualTo(ACCESS_TOKEN);
+            assertThat(result.itemId()).isEqualTo(ITEM_ID);
+        }
+
+        @Test
+        @SuppressWarnings("unchecked")
+        void exchangePublicToken_givenExpiredPublicToken_throwsProviderAuthException() {
+            // Simulate what the real onStatus(401) handler emits: ProviderAuthException.
+            stubPlaidPostError(new ProviderAuthException(
+                    ProviderType.M1_FINANCE,
+                    "Plaid rejected the public token — it may have expired or already been exchanged"));
+
+            assertThatThrownBy(() ->
+                    service.exchangePublicToken(PUBLIC_TOKEN, ProviderType.M1_FINANCE))
+                    .isInstanceOf(ProviderAuthException.class)
+                    .hasMessageContaining("public token");
+        }
+
+        @Test
+        @SuppressWarnings("unchecked")
+        void exchangePublicToken_givenPlaidRateLimit_throwsProviderRateLimitException() {
+            // Simulate what the real onStatus(429) handler emits: ProviderRateLimitException.
+            stubPlaidPostError(new ProviderRateLimitException(
+                    ProviderType.M1_FINANCE,
+                    "Plaid API rate limit exceeded on /item/public_token/exchange"));
+
+            assertThatThrownBy(() ->
+                    service.exchangePublicToken(PUBLIC_TOKEN, ProviderType.M1_FINANCE))
+                    .isInstanceOf(ProviderRateLimitException.class);
+        }
+
+        @Test
+        @SuppressWarnings("unchecked")
+        void exchangePublicToken_givenPlaid4xxClientError_throwsProviderException() {
+            // Simulate what the real onStatus(4xx) handler emits for non-401/429 codes.
+            stubPlaidPostError(new ProviderException(
+                    ProviderType.M1_FINANCE,
+                    "Plaid returned client error on /item/public_token/exchange: HTTP 400"));
+
+            assertThatThrownBy(() ->
+                    service.exchangePublicToken(PUBLIC_TOKEN, ProviderType.M1_FINANCE))
+                    .isInstanceOf(ProviderException.class)
+                    .hasMessageContaining("client error");
+        }
+
+        @Test
+        @SuppressWarnings("unchecked")
+        void exchangePublicToken_givenPlaid5xxServerError_throwsProviderException() {
+            // Simulate what the real onStatus(5xx) handler emits.
+            stubPlaidPostError(new ProviderException(
+                    ProviderType.M1_FINANCE,
+                    "Plaid returned server error on /item/public_token/exchange: HTTP 500"));
+
+            assertThatThrownBy(() ->
+                    service.exchangePublicToken(PUBLIC_TOKEN, ProviderType.M1_FINANCE))
+                    .isInstanceOf(ProviderException.class)
+                    .hasMessageContaining("server error");
+        }
+
+        @Test
+        @SuppressWarnings("unchecked")
+        void exchangePublicToken_givenNetworkFailure_throwsProviderException() {
+            // Non-ProviderException throwables are caught by wrapNonProviderException
+            // and wrapped into a ProviderException with "Failed to reach Plaid API".
+            stubPlaidPostError(new java.net.ConnectException("Connection refused"));
+
+            assertThatThrownBy(() ->
+                    service.exchangePublicToken(PUBLIC_TOKEN, ProviderType.M1_FINANCE))
+                    .isInstanceOf(ProviderException.class)
+                    .hasMessageContaining("Failed to reach Plaid API");
+        }
+
+        @Test
+        @SuppressWarnings("unchecked")
+        void exchangePublicToken_givenNullAccessTokenInResponse_throwsProviderException() {
+            stubPlaidPost(new PlaidPublicTokenExchangeResponse(null, ITEM_ID, "req-null"));
+
+            assertThatThrownBy(() ->
+                    service.exchangePublicToken(PUBLIC_TOKEN, ProviderType.M1_FINANCE))
+                    .isInstanceOf(ProviderException.class)
+                    .hasMessageContaining("empty token exchange");
+        }
+
+        @Test
+        @SuppressWarnings("unchecked")
+        void exchangePublicToken_givenNullResponse_throwsProviderException() {
+            stubPlaidPostNull(PlaidPublicTokenExchangeResponse.class);
+
+            assertThatThrownBy(() ->
+                    service.exchangePublicToken(PUBLIC_TOKEN, ProviderType.M1_FINANCE))
+                    .isInstanceOf(ProviderException.class)
+                    .hasMessageContaining("empty token exchange");
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Stub helpers
+    // -------------------------------------------------------------------------
+
+    /**
+     * Stubs the POST chain to return a successful Mono wrapping the given response object.
+     * Works for both {@link PlaidLinkTokenCreateResponse} and {@link PlaidPublicTokenExchangeResponse}
+     * because the chain topology is identical for both Plaid endpoints.
+     */
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private <T> void stubPlaidPost(T responseBody) {
+        when(plaidWebClient.post()).thenReturn(requestBodyUriSpec);
+        when(requestBodyUriSpec.uri(anyString())).thenReturn(requestBodySpec);
+        when(requestBodySpec.bodyValue(any())).thenReturn((WebClient.RequestHeadersSpec) requestHeadersSpec);
+        when(requestHeadersSpec.retrieve()).thenReturn(responseSpec);
+        when(responseSpec.onStatus(any(), any())).thenReturn(responseSpec);
+        when(responseSpec.bodyToMono((Class<T>) responseBody.getClass()))
+                .thenReturn(Mono.just(responseBody));
+    }
+
+    /**
+     * Stubs the POST chain to return a Mono that errors with the given exception.
+     * Simulates HTTP errors or network failures from the Plaid API.
+     */
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private void stubPlaidPostError(Exception error) {
+        when(plaidWebClient.post()).thenReturn(requestBodyUriSpec);
+        when(requestBodyUriSpec.uri(anyString())).thenReturn(requestBodySpec);
+        when(requestBodySpec.bodyValue(any())).thenReturn((WebClient.RequestHeadersSpec) requestHeadersSpec);
+        when(requestHeadersSpec.retrieve()).thenReturn(responseSpec);
+        when(responseSpec.onStatus(any(), any())).thenReturn(responseSpec);
+        // Both response types share the same error Mono — use Object.class as the widest type
+        when(responseSpec.bodyToMono(any(Class.class))).thenReturn(Mono.error(error));
+    }
+
+    /**
+     * Stubs the POST chain to return {@code Mono.empty()} (null after {@code .block()}),
+     * exercising the null-guard branches in both service methods.
+     */
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private void stubPlaidPostNull(Class<?> responseType) {
+        when(plaidWebClient.post()).thenReturn(requestBodyUriSpec);
+        when(requestBodyUriSpec.uri(anyString())).thenReturn(requestBodySpec);
+        when(requestBodySpec.bodyValue(any())).thenReturn((WebClient.RequestHeadersSpec) requestHeadersSpec);
+        when(requestHeadersSpec.retrieve()).thenReturn(responseSpec);
+        when(responseSpec.onStatus(any(), any())).thenReturn(responseSpec);
+        when(responseSpec.bodyToMono(any(Class.class))).thenReturn(Mono.empty());
+    }
+}

--- a/frontend/src/api/integrations.ts
+++ b/frontend/src/api/integrations.ts
@@ -6,6 +6,9 @@ import type {
   SyncResultResponse,
   NetWorthResponse,
   NetWorthHistoryResponse,
+  PlaidProvider,
+  PlaidLinkTokenResponse,
+  PlaidExchangeRequest,
 } from '@/types'
 
 export const integrationsApi = {
@@ -39,5 +42,15 @@ export const integrationsApi = {
     return api
       .get<NetWorthHistoryResponse>('/integrations/net-worth/history', { params: { days } })
       .then((r) => r.data)
+  },
+
+  createPlaidLinkToken(provider: PlaidProvider): Promise<PlaidLinkTokenResponse> {
+    return api
+      .post<PlaidLinkTokenResponse>('/integrations/plaid/link-token', null, { params: { provider } })
+      .then((r) => r.data)
+  },
+
+  exchangePlaidToken(req: PlaidExchangeRequest): Promise<AccountResponse[]> {
+    return api.post<AccountResponse[]>('/integrations/plaid/exchange', req).then((r) => r.data)
   },
 }

--- a/frontend/src/composables/usePlaidLink.ts
+++ b/frontend/src/composables/usePlaidLink.ts
@@ -1,3 +1,5 @@
+import { ref, watch, onUnmounted, type Ref } from 'vue'
+
 // Type declaration for the Plaid Link SDK loaded from CDN
 declare global {
   interface Window {
@@ -37,15 +39,31 @@ export interface PlaidExitMetadata {
   status: string | null
 }
 
-import { ref, onUnmounted } from 'vue'
-
 const PLAID_SCRIPT_URL = 'https://cdn.plaid.com/link/v2/stable/link-initialize.js'
 const PLAID_SCRIPT_ID = 'plaid-link-script'
 
+let scriptLoadPromise: Promise<void> | null = null
+
 function loadPlaidScript(): Promise<void> {
-  return new Promise((resolve, reject) => {
-    if (document.getElementById(PLAID_SCRIPT_ID)) {
+  if (scriptLoadPromise) return scriptLoadPromise
+  scriptLoadPromise = new Promise((resolve, reject) => {
+    if (window.Plaid) {
       resolve()
+      return
+    }
+    const existing = document.getElementById(PLAID_SCRIPT_ID)
+    if (existing) {
+      // Script tag exists but Plaid not ready yet — poll briefly
+      const check = setInterval(() => {
+        if (window.Plaid) {
+          clearInterval(check)
+          resolve()
+        }
+      }, 50)
+      setTimeout(() => {
+        clearInterval(check)
+        reject(new Error('Plaid SDK load timeout'))
+      }, 10000)
       return
     }
     const script = document.createElement('script')
@@ -55,51 +73,59 @@ function loadPlaidScript(): Promise<void> {
     script.onerror = () => reject(new Error('Failed to load Plaid Link SDK'))
     document.head.appendChild(script)
   })
+  return scriptLoadPromise
 }
 
 export interface UsePlaidLinkOptions {
-  linkToken: string
+  linkToken: Ref<string | null>
   onSuccess: (publicToken: string, metadata: PlaidSuccessMetadata) => void
   onExit?: (err: PlaidExitError | null, metadata: PlaidExitMetadata) => void
 }
 
+/**
+ * Composable for Plaid Link SDK. Must be called at component setup level.
+ * Set linkToken ref to trigger handler creation; call open() to launch.
+ */
 export function usePlaidLink(options: UsePlaidLinkOptions) {
   const ready = ref(false)
   let handler: PlaidHandler | null = null
 
-  loadPlaidScript()
-    .then(() => {
+  function destroyHandler() {
+    handler?.destroy()
+    handler = null
+    ready.value = false
+  }
+
+  watch(options.linkToken, async (token) => {
+    destroyHandler()
+    if (!token) return
+
+    try {
+      await loadPlaidScript()
       handler = window.Plaid.create({
-        token: options.linkToken,
+        token,
         onSuccess: (publicToken, metadata) => {
           options.onSuccess(publicToken, metadata)
         },
         onExit: (err, metadata) => {
-          if (options.onExit) {
-            options.onExit(err, metadata)
-          }
+          options.onExit?.(err, metadata)
         },
         onLoad: () => {
           ready.value = true
         },
       })
-    })
-    .catch((err: unknown) => {
-      console.error('[usePlaidLink] Script load error:', err)
-    })
+    } catch (err) {
+      console.error('[usePlaidLink] Failed to initialize:', err)
+    }
+  })
 
   function open() {
     handler?.open()
   }
 
-  function destroy() {
-    handler?.destroy()
-    handler = null
-  }
-
   onUnmounted(() => {
-    destroy()
+    destroyHandler()
   })
 
-  return { ready, open, destroy }
+  return { ready, open, destroy: destroyHandler }
 }

--- a/frontend/src/composables/usePlaidLink.ts
+++ b/frontend/src/composables/usePlaidLink.ts
@@ -1,0 +1,105 @@
+// Type declaration for the Plaid Link SDK loaded from CDN
+declare global {
+  interface Window {
+    Plaid: {
+      create(config: PlaidCreateConfig): PlaidHandler
+    }
+  }
+}
+
+interface PlaidCreateConfig {
+  token: string
+  onSuccess: (publicToken: string, metadata: PlaidSuccessMetadata) => void
+  onExit: (err: PlaidExitError | null, metadata: PlaidExitMetadata) => void
+  onLoad: () => void
+}
+
+interface PlaidHandler {
+  open(): void
+  destroy(): void
+}
+
+export interface PlaidSuccessMetadata {
+  institution: { name: string; institution_id: string } | null
+  accounts: Array<{ id: string; name: string; mask: string; type: string; subtype: string }>
+  link_session_id: string
+}
+
+export interface PlaidExitError {
+  error_type: string
+  error_code: string
+  error_message: string
+  display_message: string | null
+}
+
+export interface PlaidExitMetadata {
+  link_session_id: string
+  status: string | null
+}
+
+import { ref, onUnmounted } from 'vue'
+
+const PLAID_SCRIPT_URL = 'https://cdn.plaid.com/link/v2/stable/link-initialize.js'
+const PLAID_SCRIPT_ID = 'plaid-link-script'
+
+function loadPlaidScript(): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (document.getElementById(PLAID_SCRIPT_ID)) {
+      resolve()
+      return
+    }
+    const script = document.createElement('script')
+    script.id = PLAID_SCRIPT_ID
+    script.src = PLAID_SCRIPT_URL
+    script.onload = () => resolve()
+    script.onerror = () => reject(new Error('Failed to load Plaid Link SDK'))
+    document.head.appendChild(script)
+  })
+}
+
+export interface UsePlaidLinkOptions {
+  linkToken: string
+  onSuccess: (publicToken: string, metadata: PlaidSuccessMetadata) => void
+  onExit?: (err: PlaidExitError | null, metadata: PlaidExitMetadata) => void
+}
+
+export function usePlaidLink(options: UsePlaidLinkOptions) {
+  const ready = ref(false)
+  let handler: PlaidHandler | null = null
+
+  loadPlaidScript()
+    .then(() => {
+      handler = window.Plaid.create({
+        token: options.linkToken,
+        onSuccess: (publicToken, metadata) => {
+          options.onSuccess(publicToken, metadata)
+        },
+        onExit: (err, metadata) => {
+          if (options.onExit) {
+            options.onExit(err, metadata)
+          }
+        },
+        onLoad: () => {
+          ready.value = true
+        },
+      })
+    })
+    .catch((err: unknown) => {
+      console.error('[usePlaidLink] Script load error:', err)
+    })
+
+  function open() {
+    handler?.open()
+  }
+
+  function destroy() {
+    handler?.destroy()
+    handler = null
+  }
+
+  onUnmounted(() => {
+    destroy()
+  })
+
+  return { ready, open, destroy }
+}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -218,3 +218,17 @@ export interface NetWorthDataPoint {
   date: string
   totalUsd: number
 }
+
+// ── Plaid ────────────────────────────────────────────────────────────────────
+
+export type PlaidProvider = 'M1_FINANCE' | 'MARCUS'
+
+export interface PlaidLinkTokenResponse {
+  linkToken: string
+  expiration: string
+}
+
+export interface PlaidExchangeRequest {
+  publicToken: string
+  provider: PlaidProvider
+}

--- a/frontend/src/views/AccountsView.vue
+++ b/frontend/src/views/AccountsView.vue
@@ -239,17 +239,11 @@
               <option value="BITCOIN_WALLET">
                 Bitcoin Wallet
               </option>
-              <option
-                value="M1_FINANCE"
-                disabled
-              >
-                M1 Finance (Coming Soon)
+              <option value="M1_FINANCE">
+                M1 Finance
               </option>
-              <option
-                value="MARCUS"
-                disabled
-              >
-                Marcus by Goldman Sachs (Coming Soon)
+              <option value="MARCUS">
+                Marcus by Goldman Sachs
               </option>
             </select>
           </div>
@@ -287,6 +281,19 @@
               >
             </div>
           </template>
+          <template
+            v-else-if="
+              connectForm.providerType === 'M1_FINANCE' || connectForm.providerType === 'MARCUS'
+            "
+          >
+            <div class="rounded-lg border border-gray-100 bg-gray-50 px-4 py-3 text-sm text-gray-600">
+              <p class="font-medium text-gray-700 mb-1">Secure Bank Login via Plaid</p>
+              <p>
+                Your credentials are entered directly with your bank through Plaid's secure
+                interface — KeyBudget never sees them.
+              </p>
+            </div>
+          </template>
 
           <p
             v-if="connectFormError"
@@ -295,7 +302,11 @@
             {{ connectFormError }}
           </p>
 
-          <div class="flex gap-3 pt-1">
+          <!-- Buttons for credential-based providers -->
+          <div
+            v-if="!plaidProvider"
+            class="flex gap-3 pt-1"
+          >
             <button
               type="button"
               class="flex-1 px-4 py-2 text-sm font-medium text-gray-700 border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors"
@@ -309,6 +320,28 @@
               class="flex-1 px-4 py-2 text-sm font-medium text-white bg-primary-600 rounded-lg hover:bg-primary-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
             >
               {{ submittingConnect ? 'Connecting…' : 'Connect' }}
+            </button>
+          </div>
+
+          <!-- Buttons for Plaid-based providers -->
+          <div
+            v-else
+            class="flex gap-3 pt-1"
+          >
+            <button
+              type="button"
+              class="flex-1 px-4 py-2 text-sm font-medium text-gray-700 border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors"
+              @click="showConnectModal = false"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              :disabled="plaidLoading"
+              class="flex-1 px-4 py-2 text-sm font-medium text-white bg-primary-600 rounded-lg hover:bg-primary-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+              @click="launchPlaidLink"
+            >
+              {{ plaidLoading ? 'Opening…' : 'Connect via Bank Login' }}
             </button>
           </div>
         </form>
@@ -360,8 +393,10 @@
 </template>
 
 <script setup lang="ts">
-  import { ref, reactive, watch, onMounted } from 'vue'
+  import { ref, reactive, computed, watch, onMounted } from 'vue'
   import { useIntegrationsStore } from '@/stores/integrations'
+  import { integrationsApi } from '@/api/integrations'
+  import { usePlaidLink } from '@/composables/usePlaidLink'
   import { formatMoney } from '@/utils/formatting'
   import {
     providerLabel,
@@ -371,7 +406,7 @@
     statusClass,
     timeAgo,
   } from '@/utils/providers'
-  import type { ProviderStatusResponse, ProviderType } from '@/types'
+  import type { ProviderStatusResponse, ProviderType, PlaidProvider } from '@/types'
 
   const store = useIntegrationsStore()
   const syncing = ref<number | null>(null)
@@ -433,6 +468,56 @@
       }
     } finally {
       submittingConnect.value = false
+    }
+  }
+
+  // ── Plaid ──────────────────────────────────────────────────────────────────
+
+  const plaidLoading = ref(false)
+
+  const plaidProvider = computed<PlaidProvider | null>(() =>
+    connectForm.providerType === 'M1_FINANCE' || connectForm.providerType === 'MARCUS'
+      ? (connectForm.providerType as PlaidProvider)
+      : null,
+  )
+
+  async function launchPlaidLink() {
+    if (!plaidProvider.value) return
+    plaidLoading.value = true
+    connectFormError.value = ''
+    try {
+      const { linkToken } = await integrationsApi.createPlaidLinkToken(plaidProvider.value)
+
+      const provider = plaidProvider.value
+
+      const { open } = usePlaidLink({
+        linkToken,
+        onSuccess: async (publicToken) => {
+          try {
+            await integrationsApi.exchangePlaidToken({ publicToken, provider })
+            await store.fetchAll()
+            showConnectModal.value = false
+            connectForm.providerType = ''
+            connectForm.credentials = {}
+          } catch (err: unknown) {
+            const axiosErr = err as { response?: { data?: { message?: string } } }
+            connectFormError.value =
+              axiosErr?.response?.data?.message || 'Failed to connect account. Please try again.'
+          } finally {
+            plaidLoading.value = false
+          }
+        },
+        onExit: (_err) => {
+          plaidLoading.value = false
+        },
+      })
+
+      open()
+    } catch (err: unknown) {
+      const axiosErr = err as { response?: { data?: { message?: string } } }
+      connectFormError.value =
+        axiosErr?.response?.data?.message || 'Failed to start bank login. Please try again.'
+      plaidLoading.value = false
     }
   }
 

--- a/frontend/src/views/AccountsView.vue
+++ b/frontend/src/views/AccountsView.vue
@@ -474,6 +474,8 @@
   // ── Plaid ──────────────────────────────────────────────────────────────────
 
   const plaidLoading = ref(false)
+  const plaidLinkToken = ref<string | null>(null)
+  const pendingPlaidProvider = ref<PlaidProvider | null>(null)
 
   const plaidProvider = computed<PlaidProvider | null>(() =>
     connectForm.providerType === 'M1_FINANCE' || connectForm.providerType === 'MARCUS'
@@ -481,38 +483,52 @@
       : null,
   )
 
+  // Setup-level composable — safe for onUnmounted lifecycle
+  const { open: openPlaidLink, ready: plaidReady } = usePlaidLink({
+    linkToken: plaidLinkToken,
+    onSuccess: async (publicToken) => {
+      try {
+        if (!pendingPlaidProvider.value) return
+        await integrationsApi.exchangePlaidToken({
+          publicToken,
+          provider: pendingPlaidProvider.value,
+        })
+        await store.fetchAll()
+        showConnectModal.value = false
+        connectForm.providerType = ''
+        connectForm.credentials = {}
+      } catch (err: unknown) {
+        const axiosErr = err as { response?: { data?: { message?: string } } }
+        connectFormError.value =
+          axiosErr?.response?.data?.message || 'Failed to connect account. Please try again.'
+      } finally {
+        plaidLoading.value = false
+        plaidLinkToken.value = null
+        pendingPlaidProvider.value = null
+      }
+    },
+    onExit: () => {
+      plaidLoading.value = false
+      plaidLinkToken.value = null
+      pendingPlaidProvider.value = null
+    },
+  })
+
   async function launchPlaidLink() {
     if (!plaidProvider.value) return
     plaidLoading.value = true
     connectFormError.value = ''
     try {
       const { linkToken } = await integrationsApi.createPlaidLinkToken(plaidProvider.value)
-
-      const provider = plaidProvider.value
-
-      const { open } = usePlaidLink({
-        linkToken,
-        onSuccess: async (publicToken) => {
-          try {
-            await integrationsApi.exchangePlaidToken({ publicToken, provider })
-            await store.fetchAll()
-            showConnectModal.value = false
-            connectForm.providerType = ''
-            connectForm.credentials = {}
-          } catch (err: unknown) {
-            const axiosErr = err as { response?: { data?: { message?: string } } }
-            connectFormError.value =
-              axiosErr?.response?.data?.message || 'Failed to connect account. Please try again.'
-          } finally {
-            plaidLoading.value = false
-          }
-        },
-        onExit: (_err) => {
-          plaidLoading.value = false
-        },
-      })
-
-      open()
+      pendingPlaidProvider.value = plaidProvider.value
+      plaidLinkToken.value = linkToken
+      // Wait for Plaid SDK to initialize, then open
+      const unwatch = watch(plaidReady, (isReady) => {
+        if (isReady) {
+          unwatch()
+          openPlaidLink()
+        }
+      }, { immediate: true })
     } catch (err: unknown) {
       const axiosErr = err as { response?: { data?: { message?: string } } }
       connectFormError.value =


### PR DESCRIPTION
## Summary
- Add Plaid Link backend: PlaidConfig, PlaidService/Impl, link-token and exchange endpoints
- Add Plaid Link frontend: usePlaidLink composable with CDN script loader, AccountsView integration
- Add Plaid wire DTOs and frontend types/API methods
- Uses Plaid Development mode ($0/month) for real financial data
- Code review fixes: proper lifecycle management, provider parameterization, config cleanup

## What
Full Plaid Link integration enabling M1 Finance and Marcus connections via the Plaid SDK. Backend creates link tokens and exchanges public tokens for permanent access tokens. Frontend loads Plaid Link SDK from CDN and manages the connection flow.

## Why
M1 Finance and Marcus don't have direct APIs. Plaid provides a unified interface to connect these institutions with real data at no cost (Development tier, up to 5 Items).

## Test plan
- [ ] Verify backend compiles cleanly
- [ ] Verify Plaid link-token creation returns valid token
- [ ] Verify Plaid Link SDK opens in frontend
- [ ] Verify public token exchange creates accounts
- [ ] Verify error handling for invalid providers
- [ ] Run full QA suite

?? Generated with [Claude Code](https://claude.com/claude-code)