### PR TITLE
Dark mode, manual balance providers, logging & dev fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,9 @@ application-local.properties
 application-secrets.properties
 application-dev.properties
 
+# Logs
+logs/
+
 # OS
 .DS_Store
 Thumbs.db

--- a/backend/src/main/java/com/keybudget/integration/provider/m1finance/M1FinanceProvider.java
+++ b/backend/src/main/java/com/keybudget/integration/provider/m1finance/M1FinanceProvider.java
@@ -1,9 +1,13 @@
 package com.keybudget.integration.provider.m1finance;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.keybudget.integration.AccountType;
 import com.keybudget.integration.IntegrationProvider;
 import com.keybudget.integration.ProviderType;
 import com.keybudget.integration.exception.ProviderException;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.math.BigDecimal;
@@ -12,18 +16,27 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * M1 Finance brokerage provider.
- * Uses Plaid for brokerage data access (Dev tier: $0/month, free sandbox).
+ * M1 Finance brokerage provider — manual balance entry mode.
  *
- * <p>To enable: sign up at https://dashboard.plaid.com (free),
- * set PLAID_CLIENT_ID and PLAID_SECRET env vars, then use Plaid Link
- * on the frontend to connect the M1 Finance account.
+ * <p>M1 Finance does not expose a public API for personal use, and Plaid requires
+ * a business application for Development/Production access. This provider accepts
+ * a user-entered balance that can be updated periodically via the sync/edit flow.
  *
- * <p>Current status: sandbox-ready stub. Returns a demo account when
- * Plaid is not configured; real implementation requires Plaid Link flow.
+ * <p>Credentials map: {@code {"balance": "12345.67", "accountName": "My M1 Brokerage"}}
  */
+@Slf4j
 @Service
 public class M1FinanceProvider implements IntegrationProvider {
+
+    private static final String KEY_BALANCE = "balance";
+    private static final String KEY_ACCOUNT_NAME = "accountName";
+    private static final String DEFAULT_ACCOUNT_NAME = "M1 Finance Brokerage";
+
+    private final ObjectMapper objectMapper;
+
+    public M1FinanceProvider(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
 
     @Override
     public ProviderType getProviderType() {
@@ -32,39 +45,68 @@ public class M1FinanceProvider implements IntegrationProvider {
 
     @Override
     public List<DiscoveredAccount> connect(Map<String, String> credentials) {
-        // In production, this would exchange a Plaid public_token for an access_token
-        // and then call /investments/holdings/get to discover brokerage accounts.
-        String accessToken = credentials.get("plaidAccessToken");
-        if (accessToken == null || accessToken.isBlank()) {
-            throw new ProviderException(ProviderType.M1_FINANCE, "M1 Finance requires Plaid Link integration. " +
-                    "Sign up at https://dashboard.plaid.com (free) to enable.");
-        }
+        BigDecimal balance = parseBalance(credentials.get(KEY_BALANCE));
+        String accountName = credentials.getOrDefault(KEY_ACCOUNT_NAME, DEFAULT_ACCOUNT_NAME);
+        if (accountName.isBlank()) accountName = DEFAULT_ACCOUNT_NAME;
+
+        log.info("M1 Finance connected (manual): accountName={}, balance={}",
+                accountName, balance);
 
         return List.of(new DiscoveredAccount(
-                "m1-brokerage-demo",
-                "M1 Finance Brokerage",
+                "m1-manual",
+                accountName,
                 AccountType.BROKERAGE,
                 "USD",
-                BigDecimal.ZERO,
-                BigDecimal.ZERO
+                balance,
+                balance
         ));
     }
 
     @Override
     public List<ProviderBalance> syncBalances(String decryptedCredentialData) {
-        // In production, this would call Plaid /investments/holdings/get
-        // For the POC, return zero balance
+        Map<String, String> creds = parseCredentialJson(decryptedCredentialData);
+        BigDecimal balance = parseBalance(creds.get(KEY_BALANCE));
+
         return List.of(new ProviderBalance(
-                "m1-brokerage-demo",
-                BigDecimal.ZERO,
-                BigDecimal.ZERO,
+                "m1-manual",
+                balance,
+                balance,
                 Instant.now()
         ));
     }
 
     @Override
     public boolean validateCredential(String decryptedCredentialData) {
-        // Would call Plaid /item/get to verify the token is still valid
-        return decryptedCredentialData != null && !decryptedCredentialData.isBlank();
+        try {
+            Map<String, String> creds = parseCredentialJson(decryptedCredentialData);
+            parseBalance(creds.get(KEY_BALANCE));
+            return true;
+        } catch (Exception ex) {
+            return false;
+        }
+    }
+
+    private BigDecimal parseBalance(String raw) {
+        if (raw == null || raw.isBlank()) {
+            throw new IllegalArgumentException("Balance is required for M1 Finance (manual entry)");
+        }
+        try {
+            BigDecimal balance = new BigDecimal(raw.trim());
+            if (balance.signum() < 0) {
+                throw new IllegalArgumentException("Balance cannot be negative");
+            }
+            return balance.setScale(2, java.math.RoundingMode.HALF_UP);
+        } catch (NumberFormatException ex) {
+            throw new IllegalArgumentException("Invalid balance format: " + raw);
+        }
+    }
+
+    private Map<String, String> parseCredentialJson(String json) {
+        try {
+            return objectMapper.readValue(json, new TypeReference<>() {});
+        } catch (JsonProcessingException ex) {
+            throw new ProviderException(ProviderType.M1_FINANCE,
+                    "Failed to parse stored credential JSON", ex);
+        }
     }
 }

--- a/backend/src/main/java/com/keybudget/integration/provider/marcus/MarcusProvider.java
+++ b/backend/src/main/java/com/keybudget/integration/provider/marcus/MarcusProvider.java
@@ -1,9 +1,13 @@
 package com.keybudget.integration.provider.marcus;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.keybudget.integration.AccountType;
 import com.keybudget.integration.IntegrationProvider;
 import com.keybudget.integration.ProviderType;
 import com.keybudget.integration.exception.ProviderException;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.math.BigDecimal;
@@ -12,18 +16,27 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Marcus by Goldman Sachs savings account provider.
- * Uses Plaid for bank data access (Dev tier: $0/month, free sandbox).
+ * Marcus by Goldman Sachs savings account provider — manual balance entry mode.
  *
- * <p>To enable: sign up at https://dashboard.plaid.com (free),
- * set PLAID_CLIENT_ID and PLAID_SECRET env vars, then use Plaid Link
- * on the frontend to connect the Marcus account.
+ * <p>Marcus does not expose a public API for personal use, and Plaid requires
+ * a business application for Development/Production access. This provider accepts
+ * a user-entered balance that can be updated periodically via the sync/edit flow.
  *
- * <p>Current status: sandbox-ready stub. Returns a demo account when
- * Plaid is not configured; real implementation requires Plaid Link flow.
+ * <p>Credentials map: {@code {"balance": "50000.00", "accountName": "Marcus Savings"}}
  */
+@Slf4j
 @Service
 public class MarcusProvider implements IntegrationProvider {
+
+    private static final String KEY_BALANCE = "balance";
+    private static final String KEY_ACCOUNT_NAME = "accountName";
+    private static final String DEFAULT_ACCOUNT_NAME = "Marcus High-Yield Savings";
+
+    private final ObjectMapper objectMapper;
+
+    public MarcusProvider(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
 
     @Override
     public ProviderType getProviderType() {
@@ -32,40 +45,68 @@ public class MarcusProvider implements IntegrationProvider {
 
     @Override
     public List<DiscoveredAccount> connect(Map<String, String> credentials) {
-        // In production, this would exchange a Plaid public_token for an access_token
-        // and then call /accounts/get to discover savings accounts.
-        // For the POC, return a demo account so the UI works end-to-end.
-        String accessToken = credentials.get("plaidAccessToken");
-        if (accessToken == null || accessToken.isBlank()) {
-            throw new ProviderException(ProviderType.MARCUS, "Marcus requires Plaid Link integration. " +
-                    "Sign up at https://dashboard.plaid.com (free) to enable.");
-        }
+        BigDecimal balance = parseBalance(credentials.get(KEY_BALANCE));
+        String accountName = credentials.getOrDefault(KEY_ACCOUNT_NAME, DEFAULT_ACCOUNT_NAME);
+        if (accountName.isBlank()) accountName = DEFAULT_ACCOUNT_NAME;
+
+        log.info("Marcus connected (manual): accountName={}, balance={}",
+                accountName, balance);
 
         return List.of(new DiscoveredAccount(
-                "marcus-savings-demo",
-                "Marcus High-Yield Savings",
+                "marcus-manual",
+                accountName,
                 AccountType.SAVINGS,
                 "USD",
-                BigDecimal.ZERO,
-                BigDecimal.ZERO
+                balance,
+                balance
         ));
     }
 
     @Override
     public List<ProviderBalance> syncBalances(String decryptedCredentialData) {
-        // In production, this would call Plaid /accounts/balance/get
-        // For the POC, return zero balance
+        Map<String, String> creds = parseCredentialJson(decryptedCredentialData);
+        BigDecimal balance = parseBalance(creds.get(KEY_BALANCE));
+
         return List.of(new ProviderBalance(
-                "marcus-savings-demo",
-                BigDecimal.ZERO,
-                BigDecimal.ZERO,
+                "marcus-manual",
+                balance,
+                balance,
                 Instant.now()
         ));
     }
 
     @Override
     public boolean validateCredential(String decryptedCredentialData) {
-        // Would call Plaid /item/get to verify the token is still valid
-        return decryptedCredentialData != null && !decryptedCredentialData.isBlank();
+        try {
+            Map<String, String> creds = parseCredentialJson(decryptedCredentialData);
+            parseBalance(creds.get(KEY_BALANCE));
+            return true;
+        } catch (Exception ex) {
+            return false;
+        }
+    }
+
+    private BigDecimal parseBalance(String raw) {
+        if (raw == null || raw.isBlank()) {
+            throw new IllegalArgumentException("Balance is required for Marcus (manual entry)");
+        }
+        try {
+            BigDecimal balance = new BigDecimal(raw.trim());
+            if (balance.signum() < 0) {
+                throw new IllegalArgumentException("Balance cannot be negative");
+            }
+            return balance.setScale(2, java.math.RoundingMode.HALF_UP);
+        } catch (NumberFormatException ex) {
+            throw new IllegalArgumentException("Invalid balance format: " + raw);
+        }
+    }
+
+    private Map<String, String> parseCredentialJson(String json) {
+        try {
+            return objectMapper.readValue(json, new TypeReference<>() {});
+        } catch (JsonProcessingException ex) {
+            throw new ProviderException(ProviderType.MARCUS,
+                    "Failed to parse stored credential JSON", ex);
+        }
     }
 }

--- a/backend/src/main/resources/logback-spring.xml
+++ b/backend/src/main/resources/logback-spring.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <property name="LOG_DIR" value="${LOG_DIR:-T:/workspace/keybudget/logs}" />
+
+    <!-- Console appender (normal dev output) -->
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} %-5level [%thread] %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <!-- File appender (for Claude Code to read) -->
+    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${LOG_DIR}/backend.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>${LOG_DIR}/backend.%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+            <maxFileSize>10MB</maxFileSize>
+            <maxHistory>3</maxHistory>
+            <totalSizeCap>50MB</totalSizeCap>
+        </rollingPolicy>
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level [%thread] %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <!-- Dev profile: DEBUG for app + Spring Security -->
+    <springProfile name="dev">
+        <logger name="com.keybudget" level="DEBUG" />
+        <logger name="org.springframework.security" level="DEBUG" />
+    </springProfile>
+
+    <!-- Prod profile: INFO only -->
+    <springProfile name="prod,docker">
+        <logger name="com.keybudget" level="INFO" />
+        <logger name="org.springframework.security" level="WARN" />
+    </springProfile>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE" />
+        <appender-ref ref="FILE" />
+    </root>
+</configuration>

--- a/backend/src/test/java/com/keybudget/integration/provider/m1finance/M1FinanceProviderTest.java
+++ b/backend/src/test/java/com/keybudget/integration/provider/m1finance/M1FinanceProviderTest.java
@@ -1,0 +1,166 @@
+package com.keybudget.integration.provider.m1finance;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.keybudget.integration.AccountType;
+import com.keybudget.integration.IntegrationProvider.DiscoveredAccount;
+import com.keybudget.integration.IntegrationProvider.ProviderBalance;
+import com.keybudget.integration.ProviderType;
+import com.keybudget.integration.exception.ProviderException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class M1FinanceProviderTest {
+
+    private M1FinanceProvider provider;
+
+    @BeforeEach
+    void setUp() {
+        provider = new M1FinanceProvider(new ObjectMapper());
+    }
+
+    @Test
+    void getProviderType_returnsM1Finance() {
+        assertThat(provider.getProviderType()).isEqualTo(ProviderType.M1_FINANCE);
+    }
+
+    @Nested
+    class Connect {
+
+        @Test
+        void connect_givenValidBalance_returnsAccount() {
+            List<DiscoveredAccount> accounts =
+                    provider.connect(Map.of("balance", "12345.67", "accountName", "My M1"));
+
+            assertThat(accounts).hasSize(1);
+            DiscoveredAccount account = accounts.get(0);
+            assertThat(account.externalId()).isEqualTo("m1-manual");
+            assertThat(account.displayName()).isEqualTo("My M1");
+            assertThat(account.accountType()).isEqualTo(AccountType.BROKERAGE);
+            assertThat(account.currency()).isEqualTo("USD");
+            assertThat(account.balance()).isEqualByComparingTo("12345.67");
+            assertThat(account.balanceUsd()).isEqualByComparingTo("12345.67");
+        }
+
+        @Test
+        void connect_givenBlankAccountName_usesDefault() {
+            List<DiscoveredAccount> accounts =
+                    provider.connect(Map.of("balance", "100.00", "accountName", "  "));
+
+            assertThat(accounts.get(0).displayName()).isEqualTo("M1 Finance Brokerage");
+        }
+
+        @Test
+        void connect_givenMissingAccountName_usesDefault() {
+            List<DiscoveredAccount> accounts =
+                    provider.connect(Map.of("balance", "100.00"));
+
+            assertThat(accounts.get(0).displayName()).isEqualTo("M1 Finance Brokerage");
+        }
+
+        @Test
+        void connect_givenZeroBalance_returnsAccount() {
+            List<DiscoveredAccount> accounts =
+                    provider.connect(Map.of("balance", "0"));
+
+            assertThat(accounts.get(0).balance()).isEqualByComparingTo("0.00");
+        }
+
+        @Test
+        void connect_givenBalanceWithExtraDecimals_roundsToTwoPlaces() {
+            List<DiscoveredAccount> accounts =
+                    provider.connect(Map.of("balance", "100.999"));
+
+            assertThat(accounts.get(0).balance()).isEqualByComparingTo("101.00");
+        }
+
+        @Test
+        void connect_givenNullBalance_throwsIllegalArgument() {
+            assertThatThrownBy(() -> provider.connect(Map.of("accountName", "Test")))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("Balance is required");
+        }
+
+        @Test
+        void connect_givenBlankBalance_throwsIllegalArgument() {
+            assertThatThrownBy(() -> provider.connect(Map.of("balance", "  ")))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("Balance is required");
+        }
+
+        @Test
+        void connect_givenNegativeBalance_throwsIllegalArgument() {
+            assertThatThrownBy(() -> provider.connect(Map.of("balance", "-50.00")))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("cannot be negative");
+        }
+
+        @Test
+        void connect_givenNonNumericBalance_throwsIllegalArgument() {
+            assertThatThrownBy(() -> provider.connect(Map.of("balance", "abc")))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("Invalid balance format");
+        }
+    }
+
+    @Nested
+    class SyncBalances {
+
+        @Test
+        void syncBalances_givenValidCredential_returnsBalance() {
+            List<ProviderBalance> balances =
+                    provider.syncBalances("{\"balance\":\"5000.50\",\"accountName\":\"M1\"}");
+
+            assertThat(balances).hasSize(1);
+            ProviderBalance balance = balances.get(0);
+            assertThat(balance.externalId()).isEqualTo("m1-manual");
+            assertThat(balance.balance()).isEqualByComparingTo("5000.50");
+            assertThat(balance.balanceUsd()).isEqualByComparingTo("5000.50");
+            assertThat(balance.asOf()).isNotNull();
+        }
+
+        @Test
+        void syncBalances_givenMalformedJson_throwsProviderException() {
+            assertThatThrownBy(() -> provider.syncBalances("not-json"))
+                    .isInstanceOf(ProviderException.class)
+                    .hasMessageContaining("Failed to parse stored credential JSON");
+        }
+
+        @Test
+        void syncBalances_givenMissingBalanceField_throwsIllegalArgument() {
+            assertThatThrownBy(() -> provider.syncBalances("{\"accountName\":\"M1\"}"))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("Balance is required");
+        }
+    }
+
+    @Nested
+    class ValidateCredential {
+
+        @Test
+        void validateCredential_givenValidJson_returnsTrue() {
+            assertThat(provider.validateCredential("{\"balance\":\"100.00\"}")).isTrue();
+        }
+
+        @Test
+        void validateCredential_givenMalformedJson_returnsFalse() {
+            assertThat(provider.validateCredential("INVALID")).isFalse();
+        }
+
+        @Test
+        void validateCredential_givenMissingBalance_returnsFalse() {
+            assertThat(provider.validateCredential("{\"accountName\":\"M1\"}")).isFalse();
+        }
+
+        @Test
+        void validateCredential_givenNegativeBalance_returnsFalse() {
+            assertThat(provider.validateCredential("{\"balance\":\"-10\"}")).isFalse();
+        }
+    }
+}

--- a/backend/src/test/java/com/keybudget/integration/provider/marcus/MarcusProviderTest.java
+++ b/backend/src/test/java/com/keybudget/integration/provider/marcus/MarcusProviderTest.java
@@ -1,0 +1,166 @@
+package com.keybudget.integration.provider.marcus;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.keybudget.integration.AccountType;
+import com.keybudget.integration.IntegrationProvider.DiscoveredAccount;
+import com.keybudget.integration.IntegrationProvider.ProviderBalance;
+import com.keybudget.integration.ProviderType;
+import com.keybudget.integration.exception.ProviderException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class MarcusProviderTest {
+
+    private MarcusProvider provider;
+
+    @BeforeEach
+    void setUp() {
+        provider = new MarcusProvider(new ObjectMapper());
+    }
+
+    @Test
+    void getProviderType_returnsMarcus() {
+        assertThat(provider.getProviderType()).isEqualTo(ProviderType.MARCUS);
+    }
+
+    @Nested
+    class Connect {
+
+        @Test
+        void connect_givenValidBalance_returnsAccount() {
+            List<DiscoveredAccount> accounts =
+                    provider.connect(Map.of("balance", "50000.00", "accountName", "My Marcus"));
+
+            assertThat(accounts).hasSize(1);
+            DiscoveredAccount account = accounts.get(0);
+            assertThat(account.externalId()).isEqualTo("marcus-manual");
+            assertThat(account.displayName()).isEqualTo("My Marcus");
+            assertThat(account.accountType()).isEqualTo(AccountType.SAVINGS);
+            assertThat(account.currency()).isEqualTo("USD");
+            assertThat(account.balance()).isEqualByComparingTo("50000.00");
+            assertThat(account.balanceUsd()).isEqualByComparingTo("50000.00");
+        }
+
+        @Test
+        void connect_givenBlankAccountName_usesDefault() {
+            List<DiscoveredAccount> accounts =
+                    provider.connect(Map.of("balance", "100.00", "accountName", "  "));
+
+            assertThat(accounts.get(0).displayName()).isEqualTo("Marcus High-Yield Savings");
+        }
+
+        @Test
+        void connect_givenMissingAccountName_usesDefault() {
+            List<DiscoveredAccount> accounts =
+                    provider.connect(Map.of("balance", "100.00"));
+
+            assertThat(accounts.get(0).displayName()).isEqualTo("Marcus High-Yield Savings");
+        }
+
+        @Test
+        void connect_givenZeroBalance_returnsAccount() {
+            List<DiscoveredAccount> accounts =
+                    provider.connect(Map.of("balance", "0"));
+
+            assertThat(accounts.get(0).balance()).isEqualByComparingTo("0.00");
+        }
+
+        @Test
+        void connect_givenBalanceWithExtraDecimals_roundsToTwoPlaces() {
+            List<DiscoveredAccount> accounts =
+                    provider.connect(Map.of("balance", "100.999"));
+
+            assertThat(accounts.get(0).balance()).isEqualByComparingTo("101.00");
+        }
+
+        @Test
+        void connect_givenNullBalance_throwsIllegalArgument() {
+            assertThatThrownBy(() -> provider.connect(Map.of("accountName", "Test")))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("Balance is required");
+        }
+
+        @Test
+        void connect_givenBlankBalance_throwsIllegalArgument() {
+            assertThatThrownBy(() -> provider.connect(Map.of("balance", "  ")))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("Balance is required");
+        }
+
+        @Test
+        void connect_givenNegativeBalance_throwsIllegalArgument() {
+            assertThatThrownBy(() -> provider.connect(Map.of("balance", "-50.00")))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("cannot be negative");
+        }
+
+        @Test
+        void connect_givenNonNumericBalance_throwsIllegalArgument() {
+            assertThatThrownBy(() -> provider.connect(Map.of("balance", "abc")))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("Invalid balance format");
+        }
+    }
+
+    @Nested
+    class SyncBalances {
+
+        @Test
+        void syncBalances_givenValidCredential_returnsBalance() {
+            List<ProviderBalance> balances =
+                    provider.syncBalances("{\"balance\":\"50000.00\",\"accountName\":\"Marcus\"}");
+
+            assertThat(balances).hasSize(1);
+            ProviderBalance balance = balances.get(0);
+            assertThat(balance.externalId()).isEqualTo("marcus-manual");
+            assertThat(balance.balance()).isEqualByComparingTo("50000.00");
+            assertThat(balance.balanceUsd()).isEqualByComparingTo("50000.00");
+            assertThat(balance.asOf()).isNotNull();
+        }
+
+        @Test
+        void syncBalances_givenMalformedJson_throwsProviderException() {
+            assertThatThrownBy(() -> provider.syncBalances("not-json"))
+                    .isInstanceOf(ProviderException.class)
+                    .hasMessageContaining("Failed to parse stored credential JSON");
+        }
+
+        @Test
+        void syncBalances_givenMissingBalanceField_throwsIllegalArgument() {
+            assertThatThrownBy(() -> provider.syncBalances("{\"accountName\":\"Marcus\"}"))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("Balance is required");
+        }
+    }
+
+    @Nested
+    class ValidateCredential {
+
+        @Test
+        void validateCredential_givenValidJson_returnsTrue() {
+            assertThat(provider.validateCredential("{\"balance\":\"50000.00\"}")).isTrue();
+        }
+
+        @Test
+        void validateCredential_givenMalformedJson_returnsFalse() {
+            assertThat(provider.validateCredential("INVALID")).isFalse();
+        }
+
+        @Test
+        void validateCredential_givenMissingBalance_returnsFalse() {
+            assertThat(provider.validateCredential("{\"accountName\":\"Marcus\"}")).isFalse();
+        }
+
+        @Test
+        void validateCredential_givenNegativeBalance_returnsFalse() {
+            assertThat(provider.validateCredential("{\"balance\":\"-10\"}")).isFalse();
+        }
+    }
+}

--- a/frontend/src/utils/providers.ts
+++ b/frontend/src/utils/providers.ts
@@ -45,9 +45,9 @@ export function accountTypeLabel(type: AccountType): string {
 }
 
 export function statusClass(status: SyncStatus | string): string {
-  if (status === 'OK') return 'bg-emerald-100 text-emerald-700'
-  if (status === 'ERROR') return 'bg-red-100 text-red-700'
-  return 'bg-gray-100 text-gray-600'
+  if (status === 'OK') return 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300'
+  if (status === 'ERROR') return 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-300'
+  return 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-300'
 }
 
 export function timeAgo(iso: string): string {

--- a/frontend/src/views/AccountsView.vue
+++ b/frontend/src/views/AccountsView.vue
@@ -41,7 +41,7 @@
       v-else-if="store.error"
       class="bg-white dark:bg-gray-800 rounded-2xl border border-gray-200 dark:border-gray-700 flex flex-col items-center justify-center h-64 gap-3"
     >
-      <p class="text-sm text-red-600">
+      <p class="text-sm text-red-600 dark:text-red-400">
         {{ store.error }}
       </p>
       <button
@@ -315,7 +315,7 @@
 
           <p
             v-if="connectFormError"
-            class="text-sm text-red-600"
+            class="text-sm text-red-600 dark:text-red-400"
           >
             {{ connectFormError }}
           </p>

--- a/frontend/src/views/AccountsView.vue
+++ b/frontend/src/views/AccountsView.vue
@@ -2,10 +2,10 @@
   <div class="px-6 py-8 max-w-7xl mx-auto">
     <div class="flex items-center justify-between mb-6">
       <div>
-        <h1 class="text-2xl font-bold text-gray-900">
+        <h1 class="text-2xl font-bold text-gray-900 dark:text-white">
           Accounts
         </h1>
-        <p class="mt-1 text-sm text-gray-500">
+        <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
           Manage your connected financial providers.
         </p>
       </div>
@@ -32,14 +32,14 @@
 
     <div
       v-if="store.loading"
-      class="flex items-center justify-center h-64 text-gray-400 text-sm"
+      class="flex items-center justify-center h-64 text-gray-400 dark:text-gray-500 text-sm"
     >
       Loading…
     </div>
 
     <div
       v-else-if="store.error"
-      class="bg-white rounded-2xl border border-gray-200 flex flex-col items-center justify-center h-64 gap-3"
+      class="bg-white dark:bg-gray-800 rounded-2xl border border-gray-200 dark:border-gray-700 flex flex-col items-center justify-center h-64 gap-3"
     >
       <p class="text-sm text-red-600">
         {{ store.error }}
@@ -56,13 +56,13 @@
       <!-- Providers -->
       <div
         v-if="store.providers.length === 0"
-        class="bg-white rounded-2xl border border-gray-200 flex items-center justify-center h-64 text-gray-400 text-sm"
+        class="bg-white dark:bg-gray-800 rounded-2xl border border-gray-200 dark:border-gray-700 flex items-center justify-center h-64 text-gray-400 dark:text-gray-500 text-sm"
       >
         <div class="text-center">
-          <p class="font-medium text-gray-500">
+          <p class="font-medium text-gray-500 dark:text-gray-400">
             No providers connected
           </p>
-          <p class="text-xs mt-1">
+          <p class="text-xs mt-1 dark:text-gray-500">
             Connect Coinbase, Bitcoin, or other accounts to get started.
           </p>
         </div>
@@ -75,10 +75,10 @@
         <div
           v-for="provider in store.providers"
           :key="provider.credentialId"
-          class="bg-white rounded-2xl border border-gray-200 overflow-hidden"
+          class="bg-white dark:bg-gray-800 rounded-2xl border border-gray-200 dark:border-gray-700 overflow-hidden"
         >
           <!-- Provider header -->
-          <div class="px-6 py-4 border-b border-gray-100 flex items-center justify-between">
+          <div class="px-6 py-4 border-b border-gray-100 dark:border-gray-700 flex items-center justify-between">
             <div class="flex items-center gap-3">
               <div
                 class="w-10 h-10 rounded-lg flex items-center justify-center text-xs font-bold text-white"
@@ -87,10 +87,10 @@
                 {{ providerIcon(provider.providerType) }}
               </div>
               <div>
-                <p class="text-sm font-semibold text-gray-900">
+                <p class="text-sm font-semibold text-gray-900 dark:text-white">
                   {{ providerLabel(provider.providerType) }}
                 </p>
-                <div class="flex items-center gap-2 text-xs text-gray-500">
+                <div class="flex items-center gap-2 text-xs text-gray-500 dark:text-gray-400">
                   <span
                     class="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full text-xs font-medium"
                     :class="statusClass(provider.status)"
@@ -123,7 +123,7 @@
           <!-- Provider error -->
           <div
             v-if="provider.errorMessage"
-            class="px-6 py-2 bg-red-50 text-sm text-red-700"
+            class="px-6 py-2 bg-red-50 dark:bg-red-950 text-sm text-red-700 dark:text-red-300"
           >
             {{ provider.errorMessage }}
           </div>
@@ -132,34 +132,34 @@
           <div v-if="store.accountsByProvider(provider.credentialId).length > 0">
             <table class="w-full text-sm">
               <thead>
-                <tr class="border-b border-gray-50">
-                  <th class="px-6 py-2 text-left text-xs font-semibold text-gray-500 uppercase">
+                <tr class="border-b border-gray-50 dark:border-gray-700">
+                  <th class="px-6 py-2 text-left text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase">
                     Account
                   </th>
-                  <th class="px-6 py-2 text-left text-xs font-semibold text-gray-500 uppercase">
+                  <th class="px-6 py-2 text-left text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase">
                     Type
                   </th>
-                  <th class="px-6 py-2 text-right text-xs font-semibold text-gray-500 uppercase">
+                  <th class="px-6 py-2 text-right text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase">
                     Balance
                   </th>
-                  <th class="px-6 py-2 text-right text-xs font-semibold text-gray-500 uppercase">
+                  <th class="px-6 py-2 text-right text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase">
                     USD Value
                   </th>
                 </tr>
               </thead>
-              <tbody class="divide-y divide-gray-50">
+              <tbody class="divide-y divide-gray-50 dark:divide-gray-700">
                 <tr
                   v-for="acc in store.accountsByProvider(provider.credentialId)"
                   :key="acc.id"
-                  class="hover:bg-gray-50 transition-colors"
+                  class="hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
                 >
-                  <td class="px-6 py-3 text-gray-800 font-medium">
+                  <td class="px-6 py-3 text-gray-800 dark:text-gray-200 font-medium">
                     {{ acc.displayName }}
                   </td>
-                  <td class="px-6 py-3 text-gray-500">
+                  <td class="px-6 py-3 text-gray-500 dark:text-gray-400">
                     {{ accountTypeLabel(acc.accountType) }}
                   </td>
-                  <td class="px-6 py-3 text-right tabular-nums text-gray-600">
+                  <td class="px-6 py-3 text-right tabular-nums text-gray-600 dark:text-gray-400">
                     {{
                       acc.balance.toLocaleString(undefined, {
                         minimumFractionDigits: 2,
@@ -168,7 +168,7 @@
                     }}
                     {{ acc.currency }}
                   </td>
-                  <td class="px-6 py-3 text-right font-semibold tabular-nums text-gray-900">
+                  <td class="px-6 py-3 text-right font-semibold tabular-nums text-gray-900 dark:text-white">
                     {{ formatMoney(acc.balanceUsd) }}
                   </td>
                 </tr>
@@ -177,7 +177,7 @@
           </div>
           <div
             v-else
-            class="px-6 py-4 text-sm text-gray-400"
+            class="px-6 py-4 text-sm text-gray-400 dark:text-gray-500"
           >
             No accounts discovered yet.
           </div>
@@ -191,13 +191,13 @@
       class="fixed inset-0 z-50 flex items-center justify-center bg-gray-900/50"
       @mousedown.self="showConnectModal = false"
     >
-      <div class="bg-white rounded-2xl shadow-xl w-full max-w-md mx-4 p-6">
+      <div class="bg-white dark:bg-gray-800 rounded-2xl shadow-xl w-full max-w-md mx-4 p-6">
         <div class="flex items-center justify-between mb-5">
-          <h2 class="text-lg font-semibold text-gray-900">
+          <h2 class="text-lg font-semibold text-gray-900 dark:text-white">
             Connect Provider
           </h2>
           <button
-            class="text-gray-400 hover:text-gray-600"
+            class="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
             @click="showConnectModal = false"
           >
             <svg
@@ -221,11 +221,11 @@
           @submit.prevent="submitConnect"
         >
           <div>
-            <label class="block text-sm font-medium text-gray-700 mb-1">Provider</label>
+            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Provider</label>
             <select
               v-model="connectForm.providerType"
               required
-              class="w-full px-3 py-2 text-sm border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+              class="w-full px-3 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
             >
               <option
                 value=""
@@ -251,33 +251,33 @@
           <!-- Dynamic credential fields -->
           <template v-if="connectForm.providerType === 'COINBASE'">
             <div>
-              <label class="block text-sm font-medium text-gray-700 mb-1">API Key</label>
+              <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">API Key</label>
               <input
                 v-model="connectForm.credentials.apiKey"
                 type="text"
                 required
-                class="w-full px-3 py-2 text-sm border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+                class="w-full px-3 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
               >
             </div>
             <div>
-              <label class="block text-sm font-medium text-gray-700 mb-1">API Secret</label>
+              <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">API Secret</label>
               <input
                 v-model="connectForm.credentials.apiSecret"
                 type="password"
                 required
-                class="w-full px-3 py-2 text-sm border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+                class="w-full px-3 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
               >
             </div>
           </template>
           <template v-else-if="connectForm.providerType === 'BITCOIN_WALLET'">
             <div>
-              <label class="block text-sm font-medium text-gray-700 mb-1">Bitcoin Address</label>
+              <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Bitcoin Address</label>
               <input
                 v-model="connectForm.credentials.address"
                 type="text"
                 required
                 placeholder="bc1..."
-                class="w-full px-3 py-2 text-sm border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+                class="w-full px-3 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
               >
             </div>
           </template>
@@ -286,8 +286,10 @@
               connectForm.providerType === 'M1_FINANCE' || connectForm.providerType === 'MARCUS'
             "
           >
-            <div class="rounded-lg border border-gray-100 bg-gray-50 px-4 py-3 text-sm text-gray-600">
-              <p class="font-medium text-gray-700 mb-1">Secure Bank Login via Plaid</p>
+            <div class="rounded-lg border border-gray-100 dark:border-gray-600 bg-gray-50 dark:bg-gray-700 px-4 py-3 text-sm text-gray-600 dark:text-gray-300">
+              <p class="font-medium text-gray-700 dark:text-gray-200 mb-1">
+                Secure Bank Login via Plaid
+              </p>
               <p>
                 Your credentials are entered directly with your bank through Plaid's secure
                 interface — KeyBudget never sees them.
@@ -309,7 +311,7 @@
           >
             <button
               type="button"
-              class="flex-1 px-4 py-2 text-sm font-medium text-gray-700 border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors"
+              class="flex-1 px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
               @click="showConnectModal = false"
             >
               Cancel
@@ -330,7 +332,7 @@
           >
             <button
               type="button"
-              class="flex-1 px-4 py-2 text-sm font-medium text-gray-700 border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors"
+              class="flex-1 px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
               @click="showConnectModal = false"
             >
               Cancel
@@ -354,11 +356,11 @@
       class="fixed inset-0 z-50 flex items-center justify-center bg-gray-900/50"
       @mousedown.self="showDisconnectModal = false"
     >
-      <div class="bg-white rounded-2xl shadow-xl w-full max-w-sm mx-4 p-6">
-        <h2 class="text-lg font-semibold text-gray-900 mb-2">
+      <div class="bg-white dark:bg-gray-800 rounded-2xl shadow-xl w-full max-w-sm mx-4 p-6">
+        <h2 class="text-lg font-semibold text-gray-900 dark:text-white mb-2">
           Disconnect Provider
         </h2>
-        <p class="text-sm text-gray-600 mb-5">
+        <p class="text-sm text-gray-600 dark:text-gray-300 mb-5">
           Disconnect
           <span class="font-medium">{{
             providerLabel(disconnectTarget?.providerType ?? 'COINBASE')
@@ -373,7 +375,7 @@
         <div class="flex gap-3">
           <button
             type="button"
-            class="flex-1 px-4 py-2 text-sm font-medium text-gray-700 border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors"
+            class="flex-1 px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
             @click="showDisconnectModal = false"
           >
             Cancel

--- a/frontend/src/views/AccountsView.vue
+++ b/frontend/src/views/AccountsView.vue
@@ -286,14 +286,30 @@
               connectForm.providerType === 'M1_FINANCE' || connectForm.providerType === 'MARCUS'
             "
           >
-            <div class="rounded-lg border border-gray-100 dark:border-gray-600 bg-gray-50 dark:bg-gray-700 px-4 py-3 text-sm text-gray-600 dark:text-gray-300">
-              <p class="font-medium text-gray-700 dark:text-gray-200 mb-1">
-                Secure Bank Login via Plaid
-              </p>
-              <p>
-                Your credentials are entered directly with your bank through Plaid's secure
-                interface — KeyBudget never sees them.
-              </p>
+            <div class="rounded-lg border border-blue-100 dark:border-blue-800 bg-blue-50 dark:bg-blue-950 px-4 py-3 text-sm text-blue-700 dark:text-blue-300 mb-1">
+              Manual balance entry — log into your account and enter your current balance below.
+              You can update it anytime via the sync button.
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Account Name (optional)</label>
+              <input
+                v-model="connectForm.credentials.accountName"
+                type="text"
+                :placeholder="connectForm.providerType === 'M1_FINANCE' ? 'M1 Finance Brokerage' : 'Marcus High-Yield Savings'"
+                class="w-full px-3 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+              >
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Current Balance ($)</label>
+              <input
+                v-model="connectForm.credentials.balance"
+                type="number"
+                step="0.01"
+                min="0"
+                required
+                placeholder="0.00"
+                class="w-full px-3 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+              >
             </div>
           </template>
 
@@ -304,11 +320,7 @@
             {{ connectFormError }}
           </p>
 
-          <!-- Buttons for credential-based providers -->
-          <div
-            v-if="!plaidProvider"
-            class="flex gap-3 pt-1"
-          >
+          <div class="flex gap-3 pt-1">
             <button
               type="button"
               class="flex-1 px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
@@ -322,28 +334,6 @@
               class="flex-1 px-4 py-2 text-sm font-medium text-white bg-primary-600 rounded-lg hover:bg-primary-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
             >
               {{ submittingConnect ? 'Connecting…' : 'Connect' }}
-            </button>
-          </div>
-
-          <!-- Buttons for Plaid-based providers -->
-          <div
-            v-else
-            class="flex gap-3 pt-1"
-          >
-            <button
-              type="button"
-              class="flex-1 px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
-              @click="showConnectModal = false"
-            >
-              Cancel
-            </button>
-            <button
-              type="button"
-              :disabled="plaidLoading"
-              class="flex-1 px-4 py-2 text-sm font-medium text-white bg-primary-600 rounded-lg hover:bg-primary-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-              @click="launchPlaidLink"
-            >
-              {{ plaidLoading ? 'Opening…' : 'Connect via Bank Login' }}
             </button>
           </div>
         </form>
@@ -395,10 +385,8 @@
 </template>
 
 <script setup lang="ts">
-  import { ref, reactive, computed, watch, onMounted } from 'vue'
+  import { ref, reactive, watch, onMounted } from 'vue'
   import { useIntegrationsStore } from '@/stores/integrations'
-  import { integrationsApi } from '@/api/integrations'
-  import { usePlaidLink } from '@/composables/usePlaidLink'
   import { formatMoney } from '@/utils/formatting'
   import {
     providerLabel,
@@ -408,7 +396,7 @@
     statusClass,
     timeAgo,
   } from '@/utils/providers'
-  import type { ProviderStatusResponse, ProviderType, PlaidProvider } from '@/types'
+  import type { ProviderStatusResponse, ProviderType } from '@/types'
 
   const store = useIntegrationsStore()
   const syncing = ref<number | null>(null)
@@ -470,72 +458,6 @@
       }
     } finally {
       submittingConnect.value = false
-    }
-  }
-
-  // ── Plaid ──────────────────────────────────────────────────────────────────
-
-  const plaidLoading = ref(false)
-  const plaidLinkToken = ref<string | null>(null)
-  const pendingPlaidProvider = ref<PlaidProvider | null>(null)
-
-  const plaidProvider = computed<PlaidProvider | null>(() =>
-    connectForm.providerType === 'M1_FINANCE' || connectForm.providerType === 'MARCUS'
-      ? (connectForm.providerType as PlaidProvider)
-      : null,
-  )
-
-  // Setup-level composable — safe for onUnmounted lifecycle
-  const { open: openPlaidLink, ready: plaidReady } = usePlaidLink({
-    linkToken: plaidLinkToken,
-    onSuccess: async (publicToken) => {
-      try {
-        if (!pendingPlaidProvider.value) return
-        await integrationsApi.exchangePlaidToken({
-          publicToken,
-          provider: pendingPlaidProvider.value,
-        })
-        await store.fetchAll()
-        showConnectModal.value = false
-        connectForm.providerType = ''
-        connectForm.credentials = {}
-      } catch (err: unknown) {
-        const axiosErr = err as { response?: { data?: { message?: string } } }
-        connectFormError.value =
-          axiosErr?.response?.data?.message || 'Failed to connect account. Please try again.'
-      } finally {
-        plaidLoading.value = false
-        plaidLinkToken.value = null
-        pendingPlaidProvider.value = null
-      }
-    },
-    onExit: () => {
-      plaidLoading.value = false
-      plaidLinkToken.value = null
-      pendingPlaidProvider.value = null
-    },
-  })
-
-  async function launchPlaidLink() {
-    if (!plaidProvider.value) return
-    plaidLoading.value = true
-    connectFormError.value = ''
-    try {
-      const { linkToken } = await integrationsApi.createPlaidLinkToken(plaidProvider.value)
-      pendingPlaidProvider.value = plaidProvider.value
-      plaidLinkToken.value = linkToken
-      // Wait for Plaid SDK to initialize, then open
-      const unwatch = watch(plaidReady, (isReady) => {
-        if (isReady) {
-          unwatch()
-          openPlaidLink()
-        }
-      }, { immediate: true })
-    } catch (err: unknown) {
-      const axiosErr = err as { response?: { data?: { message?: string } } }
-      connectFormError.value =
-        axiosErr?.response?.data?.message || 'Failed to start bank login. Please try again.'
-      plaidLoading.value = false
     }
   }
 

--- a/frontend/src/views/BudgetsView.vue
+++ b/frontend/src/views/BudgetsView.vue
@@ -2,10 +2,10 @@
   <div class="px-6 py-8 max-w-7xl mx-auto">
     <div class="flex items-center justify-between mb-6">
       <div>
-        <h1 class="text-2xl font-bold text-gray-900">
+        <h1 class="text-2xl font-bold text-gray-900 dark:text-white">
           Budgets
         </h1>
-        <p class="mt-1 text-sm text-gray-500">
+        <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
           Set limits and stay on track.
         </p>
       </div>
@@ -13,7 +13,7 @@
         <input
           v-model="selectedMonth"
           type="month"
-          class="text-sm border border-gray-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+          class="text-sm border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
           @change="loadBudgets"
         >
         <button
@@ -41,7 +41,7 @@
     <!-- Loading -->
     <div
       v-if="loading"
-      class="flex items-center justify-center py-20 text-gray-400 text-sm"
+      class="flex items-center justify-center py-20 text-gray-400 dark:text-gray-500 text-sm"
     >
       Loading…
     </div>
@@ -49,11 +49,11 @@
     <!-- Empty state -->
     <div
       v-else-if="budgetsStore.budgets.length === 0"
-      class="bg-white rounded-2xl border border-gray-200"
+      class="bg-white dark:bg-gray-800 rounded-2xl border border-gray-200 dark:border-gray-700"
     >
-      <div class="flex flex-col items-center justify-center py-20 text-gray-400">
+      <div class="flex flex-col items-center justify-center py-20 text-gray-400 dark:text-gray-500">
         <svg
-          class="w-12 h-12 mb-4 text-gray-300"
+          class="w-12 h-12 mb-4 text-gray-300 dark:text-gray-600"
           fill="none"
           viewBox="0 0 24 24"
           stroke="currentColor"
@@ -71,10 +71,10 @@
             d="M20.488 9H15V3.512A9.025 9.025 0 0120.488 9z"
           />
         </svg>
-        <p class="font-medium text-gray-500">
+        <p class="font-medium text-gray-500 dark:text-gray-400">
           No budgets set
         </p>
-        <p class="text-sm mt-1">
+        <p class="text-sm mt-1 dark:text-gray-500">
           Create your first budget to start tracking spending.
         </p>
         <button
@@ -94,7 +94,7 @@
       <div
         v-for="budget in budgetsStore.budgets"
         :key="budget.id"
-        class="bg-white rounded-2xl border border-gray-200 p-5"
+        class="bg-white dark:bg-gray-800 rounded-2xl border border-gray-200 dark:border-gray-700 p-5"
       >
         <!-- Header -->
         <div class="flex items-center justify-between mb-4">
@@ -103,11 +103,11 @@
               class="inline-block w-3 h-3 rounded-full flex-shrink-0"
               :style="{ backgroundColor: budget.categoryColor }"
             />
-            <span class="text-sm font-semibold text-gray-800">{{ budget.categoryName }}</span>
+            <span class="text-sm font-semibold text-gray-800 dark:text-gray-200">{{ budget.categoryName }}</span>
           </div>
           <div class="flex items-center gap-1">
             <button
-              class="p-1.5 text-gray-400 hover:text-primary-600 rounded-lg hover:bg-primary-50 transition-colors"
+              class="p-1.5 text-gray-400 hover:text-primary-600 rounded-lg hover:bg-primary-50 dark:hover:bg-primary-900/30 transition-colors"
               title="Edit budget"
               @click="openEditModal(budget)"
             >
@@ -126,7 +126,7 @@
               </svg>
             </button>
             <button
-              class="p-1.5 text-gray-400 hover:text-red-600 rounded-lg hover:bg-red-50 transition-colors"
+              class="p-1.5 text-gray-400 hover:text-red-600 rounded-lg hover:bg-red-50 dark:hover:bg-red-900/30 transition-colors"
               title="Delete budget"
               @click="confirmDelete(budget)"
             >
@@ -149,7 +149,7 @@
 
         <!-- Progress bar -->
         <div class="mb-3">
-          <div class="w-full h-2.5 bg-gray-100 rounded-full overflow-hidden">
+          <div class="w-full h-2.5 bg-gray-100 dark:bg-gray-700 rounded-full overflow-hidden">
             <div
               class="h-full rounded-full transition-all"
               :class="budgetBarColor(budget)"
@@ -161,18 +161,18 @@
         <!-- Amounts -->
         <div class="flex justify-between text-sm">
           <div>
-            <p class="text-xs text-gray-400">
+            <p class="text-xs text-gray-400 dark:text-gray-500">
               Spent
             </p>
-            <p class="font-semibold text-gray-800 tabular-nums">
+            <p class="font-semibold text-gray-800 dark:text-gray-200 tabular-nums">
               {{ formatMoney(budget.spentAmount) }}
             </p>
           </div>
           <div class="text-right">
-            <p class="text-xs text-gray-400">
+            <p class="text-xs text-gray-400 dark:text-gray-500">
               Limit
             </p>
-            <p class="font-semibold text-gray-800 tabular-nums">
+            <p class="font-semibold text-gray-800 dark:text-gray-200 tabular-nums">
               {{ formatMoney(budget.limitAmount) }}
             </p>
           </div>
@@ -196,13 +196,13 @@
       class="fixed inset-0 z-50 flex items-center justify-center bg-gray-900/50"
       @mousedown.self="showAddModal = false"
     >
-      <div class="bg-white rounded-2xl shadow-xl w-full max-w-md mx-4 p-6">
+      <div class="bg-white dark:bg-gray-800 rounded-2xl shadow-xl w-full max-w-md mx-4 p-6">
         <div class="flex items-center justify-between mb-5">
-          <h2 class="text-lg font-semibold text-gray-900">
+          <h2 class="text-lg font-semibold text-gray-900 dark:text-white">
             New Budget
           </h2>
           <button
-            class="text-gray-400 hover:text-gray-600"
+            class="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
             @click="showAddModal = false"
           >
             <svg
@@ -227,11 +227,11 @@
         >
           <!-- Category -->
           <div>
-            <label class="block text-sm font-medium text-gray-700 mb-1">Category</label>
+            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Category</label>
             <select
               v-model.number="addForm.categoryId"
               required
-              class="w-full px-3 py-2 text-sm border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+              class="w-full px-3 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
             >
               <option
                 value=""
@@ -249,7 +249,7 @@
             </select>
             <p
               v-if="availableExpenseCategories.length === 0"
-              class="mt-1 text-xs text-gray-400"
+              class="mt-1 text-xs text-gray-400 dark:text-gray-500"
             >
               All expense categories already have a budget for this month.
             </p>
@@ -257,18 +257,18 @@
 
           <!-- Month -->
           <div>
-            <label class="block text-sm font-medium text-gray-700 mb-1">Month</label>
+            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Month</label>
             <input
               v-model="addForm.monthYear"
               type="month"
               required
-              class="w-full px-3 py-2 text-sm border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+              class="w-full px-3 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
             >
           </div>
 
           <!-- Limit -->
           <div>
-            <label class="block text-sm font-medium text-gray-700 mb-1">Monthly Limit</label>
+            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Monthly Limit</label>
             <div class="relative">
               <span class="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 text-sm">$</span>
               <input
@@ -278,7 +278,7 @@
                 min="0.01"
                 required
                 placeholder="0.00"
-                class="w-full pl-7 pr-3 py-2 text-sm border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+                class="w-full pl-7 pr-3 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
               >
             </div>
           </div>
@@ -293,7 +293,7 @@
           <div class="flex gap-3 pt-1">
             <button
               type="button"
-              class="flex-1 px-4 py-2 text-sm font-medium text-gray-700 border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors"
+              class="flex-1 px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
               @click="showAddModal = false"
             >
               Cancel
@@ -316,13 +316,13 @@
       class="fixed inset-0 z-50 flex items-center justify-center bg-gray-900/50"
       @mousedown.self="showEditModal = false"
     >
-      <div class="bg-white rounded-2xl shadow-xl w-full max-w-md mx-4 p-6">
+      <div class="bg-white dark:bg-gray-800 rounded-2xl shadow-xl w-full max-w-md mx-4 p-6">
         <div class="flex items-center justify-between mb-5">
-          <h2 class="text-lg font-semibold text-gray-900">
+          <h2 class="text-lg font-semibold text-gray-900 dark:text-white">
             Edit Budget — {{ editBudget?.categoryName }}
           </h2>
           <button
-            class="text-gray-400 hover:text-gray-600"
+            class="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
             @click="showEditModal = false"
           >
             <svg
@@ -346,7 +346,7 @@
           @submit.prevent="submitEdit"
         >
           <div>
-            <label class="block text-sm font-medium text-gray-700 mb-1">Monthly Limit</label>
+            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Monthly Limit</label>
             <div class="relative">
               <span class="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 text-sm">$</span>
               <input
@@ -356,7 +356,7 @@
                 min="0.01"
                 required
                 placeholder="0.00"
-                class="w-full pl-7 pr-3 py-2 text-sm border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+                class="w-full pl-7 pr-3 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
               >
             </div>
           </div>
@@ -371,7 +371,7 @@
           <div class="flex gap-3 pt-1">
             <button
               type="button"
-              class="flex-1 px-4 py-2 text-sm font-medium text-gray-700 border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors"
+              class="flex-1 px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
               @click="showEditModal = false"
             >
               Cancel
@@ -394,18 +394,18 @@
       class="fixed inset-0 z-50 flex items-center justify-center bg-gray-900/50"
       @mousedown.self="showDeleteModal = false"
     >
-      <div class="bg-white rounded-2xl shadow-xl w-full max-w-sm mx-4 p-6">
-        <h2 class="text-lg font-semibold text-gray-900 mb-2">
+      <div class="bg-white dark:bg-gray-800 rounded-2xl shadow-xl w-full max-w-sm mx-4 p-6">
+        <h2 class="text-lg font-semibold text-gray-900 dark:text-white mb-2">
           Delete Budget
         </h2>
-        <p class="text-sm text-gray-600 mb-6">
+        <p class="text-sm text-gray-600 dark:text-gray-300 mb-6">
           Are you sure you want to delete the
-          <span class="font-medium text-gray-800">{{ deleteBudget?.categoryName }}</span>
+          <span class="font-medium text-gray-800 dark:text-gray-200">{{ deleteBudget?.categoryName }}</span>
           budget? This action cannot be undone.
         </p>
         <div class="flex gap-3">
           <button
-            class="flex-1 px-4 py-2 text-sm font-medium text-gray-700 border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors"
+            class="flex-1 px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
             @click="showDeleteModal = false"
           >
             Cancel

--- a/frontend/src/views/CategoriesView.vue
+++ b/frontend/src/views/CategoriesView.vue
@@ -2,10 +2,10 @@
   <div class="px-6 py-8 max-w-7xl mx-auto">
     <div class="flex items-center justify-between mb-6">
       <div>
-        <h1 class="text-2xl font-bold text-gray-900">
+        <h1 class="text-2xl font-bold text-gray-900 dark:text-white">
           Categories
         </h1>
-        <p class="mt-1 text-sm text-gray-500">
+        <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
           Organize your income and expenses.
         </p>
       </div>
@@ -38,7 +38,7 @@
         class="px-4 py-2 text-sm font-medium rounded-lg transition-colors"
         :class="activeTab === tab.value
           ? 'bg-primary-600 text-white'
-          : 'bg-white text-gray-700 border border-gray-300 hover:bg-gray-50'"
+          : 'bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 border border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-700'"
         @click="activeTab = tab.value"
       >
         {{ tab.label }}
@@ -48,19 +48,19 @@
     <!-- Category grid -->
     <div
       v-if="loading"
-      class="flex items-center justify-center h-64 text-gray-400 text-sm"
+      class="flex items-center justify-center h-64 text-gray-400 dark:text-gray-500 text-sm"
     >
       Loading…
     </div>
     <div
       v-else-if="filteredCategories.length === 0"
-      class="bg-white rounded-2xl border border-gray-200 flex items-center justify-center h-64 text-gray-400 text-sm"
+      class="bg-white dark:bg-gray-800 rounded-2xl border border-gray-200 dark:border-gray-700 flex items-center justify-center h-64 text-gray-400 dark:text-gray-500 text-sm"
     >
       <div class="text-center">
-        <p class="font-medium text-gray-500">
+        <p class="font-medium text-gray-500 dark:text-gray-400">
           No {{ activeTab.toLowerCase() }} categories
         </p>
-        <p class="text-xs mt-1">
+        <p class="text-xs mt-1 dark:text-gray-500">
           Create one to get started.
         </p>
       </div>
@@ -72,7 +72,7 @@
       <div
         v-for="cat in filteredCategories"
         :key="cat.id"
-        class="bg-white rounded-2xl border border-gray-200 p-5 flex items-center justify-between hover:shadow-sm transition-shadow"
+        class="bg-white dark:bg-gray-800 rounded-2xl border border-gray-200 dark:border-gray-700 p-5 flex items-center justify-between hover:shadow-sm transition-shadow"
       >
         <div class="flex items-center gap-3">
           <div
@@ -82,10 +82,10 @@
             {{ cat.icon || '📁' }}
           </div>
           <div>
-            <p class="text-sm font-medium text-gray-900">
+            <p class="text-sm font-medium text-gray-900 dark:text-white">
               {{ cat.name }}
             </p>
-            <p class="text-xs text-gray-500">
+            <p class="text-xs text-gray-500 dark:text-gray-400">
               {{ cat.type }}
             </p>
           </div>
@@ -95,7 +95,7 @@
           class="flex gap-1"
         >
           <button
-            class="p-1.5 text-gray-400 hover:text-primary-600 rounded-lg hover:bg-primary-50 transition-colors"
+            class="p-1.5 text-gray-400 hover:text-primary-600 rounded-lg hover:bg-primary-50 dark:hover:bg-primary-900/30 transition-colors"
             title="Edit"
             @click="openEditModal(cat)"
           >
@@ -114,7 +114,7 @@
             </svg>
           </button>
           <button
-            class="p-1.5 text-gray-400 hover:text-red-600 rounded-lg hover:bg-red-50 transition-colors"
+            class="p-1.5 text-gray-400 hover:text-red-600 rounded-lg hover:bg-red-50 dark:hover:bg-red-900/30 transition-colors"
             title="Delete"
             @click="openDeleteModal(cat)"
           >
@@ -135,7 +135,7 @@
         </div>
         <span
           v-else
-          class="text-xs text-gray-400 italic"
+          class="text-xs text-gray-400 dark:text-gray-500 italic"
         >Default</span>
       </div>
     </div>
@@ -146,13 +146,13 @@
       class="fixed inset-0 z-50 flex items-center justify-center bg-gray-900/50"
       @mousedown.self="showAddModal = false"
     >
-      <div class="bg-white rounded-2xl shadow-xl w-full max-w-md mx-4 p-6">
+      <div class="bg-white dark:bg-gray-800 rounded-2xl shadow-xl w-full max-w-md mx-4 p-6">
         <div class="flex items-center justify-between mb-5">
-          <h2 class="text-lg font-semibold text-gray-900">
+          <h2 class="text-lg font-semibold text-gray-900 dark:text-white">
             Add Category
           </h2>
           <button
-            class="text-gray-400 hover:text-gray-600"
+            class="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
             @click="showAddModal = false"
           >
             <svg
@@ -176,12 +176,12 @@
           @submit.prevent="submitAdd"
         >
           <div>
-            <label class="block text-sm font-medium text-gray-700 mb-1">Type</label>
-            <div class="flex rounded-lg border border-gray-300 overflow-hidden text-sm">
+            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Type</label>
+            <div class="flex rounded-lg border border-gray-300 dark:border-gray-600 overflow-hidden text-sm">
               <button
                 type="button"
                 class="flex-1 py-2 transition-colors"
-                :class="addForm.type === 'EXPENSE' ? 'bg-red-500 text-white' : 'bg-white text-gray-700 hover:bg-gray-50'"
+                :class="addForm.type === 'EXPENSE' ? 'bg-red-500 text-white' : 'bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-600'"
                 @click="addForm.type = 'EXPENSE'"
               >
                 Expense
@@ -189,7 +189,7 @@
               <button
                 type="button"
                 class="flex-1 py-2 transition-colors"
-                :class="addForm.type === 'INCOME' ? 'bg-emerald-500 text-white' : 'bg-white text-gray-700 hover:bg-gray-50'"
+                :class="addForm.type === 'INCOME' ? 'bg-emerald-500 text-white' : 'bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-600'"
                 @click="addForm.type = 'INCOME'"
               >
                 Income
@@ -198,18 +198,18 @@
           </div>
 
           <div>
-            <label class="block text-sm font-medium text-gray-700 mb-1">Name</label>
+            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Name</label>
             <input
               v-model="addForm.name"
               type="text"
               required
               placeholder="e.g. Groceries"
-              class="w-full px-3 py-2 text-sm border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+              class="w-full px-3 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
             >
           </div>
 
           <div>
-            <label class="block text-sm font-medium text-gray-700 mb-1">
+            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
               Icon
               <span class="text-gray-400 font-normal">(emoji, optional)</span>
             </label>
@@ -218,19 +218,19 @@
               type="text"
               placeholder="e.g. 🛒"
               maxlength="4"
-              class="w-full px-3 py-2 text-sm border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+              class="w-full px-3 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
             >
           </div>
 
           <div>
-            <label class="block text-sm font-medium text-gray-700 mb-1">
+            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
               Color
               <span class="text-gray-400 font-normal">(optional)</span>
             </label>
             <input
               v-model="addForm.color"
               type="color"
-              class="w-12 h-9 border border-gray-300 rounded-lg cursor-pointer"
+              class="w-12 h-9 border border-gray-300 dark:border-gray-600 rounded-lg cursor-pointer"
             >
           </div>
 
@@ -244,7 +244,7 @@
           <div class="flex gap-3 pt-1">
             <button
               type="button"
-              class="flex-1 px-4 py-2 text-sm font-medium text-gray-700 border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors"
+              class="flex-1 px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
               @click="showAddModal = false"
             >
               Cancel
@@ -267,13 +267,13 @@
       class="fixed inset-0 z-50 flex items-center justify-center bg-gray-900/50"
       @mousedown.self="showEditModal = false"
     >
-      <div class="bg-white rounded-2xl shadow-xl w-full max-w-md mx-4 p-6">
+      <div class="bg-white dark:bg-gray-800 rounded-2xl shadow-xl w-full max-w-md mx-4 p-6">
         <div class="flex items-center justify-between mb-5">
-          <h2 class="text-lg font-semibold text-gray-900">
+          <h2 class="text-lg font-semibold text-gray-900 dark:text-white">
             Edit Category
           </h2>
           <button
-            class="text-gray-400 hover:text-gray-600"
+            class="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
             @click="showEditModal = false"
           >
             <svg
@@ -297,12 +297,12 @@
           @submit.prevent="submitEdit"
         >
           <div>
-            <label class="block text-sm font-medium text-gray-700 mb-1">Type</label>
-            <div class="flex rounded-lg border border-gray-300 overflow-hidden text-sm">
+            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Type</label>
+            <div class="flex rounded-lg border border-gray-300 dark:border-gray-600 overflow-hidden text-sm">
               <button
                 type="button"
                 class="flex-1 py-2 transition-colors"
-                :class="editForm.type === 'EXPENSE' ? 'bg-red-500 text-white' : 'bg-white text-gray-700 hover:bg-gray-50'"
+                :class="editForm.type === 'EXPENSE' ? 'bg-red-500 text-white' : 'bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-600'"
                 @click="editForm.type = 'EXPENSE'"
               >
                 Expense
@@ -310,7 +310,7 @@
               <button
                 type="button"
                 class="flex-1 py-2 transition-colors"
-                :class="editForm.type === 'INCOME' ? 'bg-emerald-500 text-white' : 'bg-white text-gray-700 hover:bg-gray-50'"
+                :class="editForm.type === 'INCOME' ? 'bg-emerald-500 text-white' : 'bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-600'"
                 @click="editForm.type = 'INCOME'"
               >
                 Income
@@ -319,17 +319,17 @@
           </div>
 
           <div>
-            <label class="block text-sm font-medium text-gray-700 mb-1">Name</label>
+            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Name</label>
             <input
               v-model="editForm.name"
               type="text"
               required
-              class="w-full px-3 py-2 text-sm border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+              class="w-full px-3 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
             >
           </div>
 
           <div>
-            <label class="block text-sm font-medium text-gray-700 mb-1">
+            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
               Icon
               <span class="text-gray-400 font-normal">(emoji, optional)</span>
             </label>
@@ -337,19 +337,19 @@
               v-model="editForm.icon"
               type="text"
               maxlength="4"
-              class="w-full px-3 py-2 text-sm border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+              class="w-full px-3 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
             >
           </div>
 
           <div>
-            <label class="block text-sm font-medium text-gray-700 mb-1">
+            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
               Color
               <span class="text-gray-400 font-normal">(optional)</span>
             </label>
             <input
               v-model="editForm.color"
               type="color"
-              class="w-12 h-9 border border-gray-300 rounded-lg cursor-pointer"
+              class="w-12 h-9 border border-gray-300 dark:border-gray-600 rounded-lg cursor-pointer"
             >
           </div>
 
@@ -363,7 +363,7 @@
           <div class="flex gap-3 pt-1">
             <button
               type="button"
-              class="flex-1 px-4 py-2 text-sm font-medium text-gray-700 border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors"
+              class="flex-1 px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
               @click="showEditModal = false"
             >
               Cancel
@@ -386,11 +386,11 @@
       class="fixed inset-0 z-50 flex items-center justify-center bg-gray-900/50"
       @mousedown.self="showDeleteModal = false"
     >
-      <div class="bg-white rounded-2xl shadow-xl w-full max-w-sm mx-4 p-6">
-        <h2 class="text-lg font-semibold text-gray-900 mb-2">
+      <div class="bg-white dark:bg-gray-800 rounded-2xl shadow-xl w-full max-w-sm mx-4 p-6">
+        <h2 class="text-lg font-semibold text-gray-900 dark:text-white mb-2">
           Delete Category
         </h2>
-        <p class="text-sm text-gray-600 mb-5">
+        <p class="text-sm text-gray-600 dark:text-gray-300 mb-5">
           Are you sure you want to delete
           <span class="font-medium">"{{ deleteTarget?.name }}"</span>?
           Transactions using this category may be affected.
@@ -406,7 +406,7 @@
         <div class="flex gap-3">
           <button
             type="button"
-            class="flex-1 px-4 py-2 text-sm font-medium text-gray-700 border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors"
+            class="flex-1 px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
             @click="showDeleteModal = false"
           >
             Cancel

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -1,10 +1,10 @@
 <template>
   <div class="px-6 py-8 max-w-7xl mx-auto">
     <div class="mb-8">
-      <h1 class="text-2xl font-bold text-gray-900">
+      <h1 class="text-2xl font-bold text-gray-900 dark:text-white">
         Good {{ greeting }}, {{ firstName }}
       </h1>
-      <p class="mt-1 text-sm text-gray-500">
+      <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
         Here's your financial overview for {{ currentMonth }}.
       </p>
     </div>
@@ -72,13 +72,13 @@
     <!-- Connect accounts CTA (shown when no providers connected) -->
     <div
       v-if="!integrationsStore.netWorth || integrationsStore.netWorth.byProvider.length === 0"
-      class="mb-8 bg-amber-50 border border-amber-200 rounded-2xl p-5 flex items-center justify-between"
+      class="mb-8 bg-amber-50 dark:bg-amber-950 border border-amber-200 dark:border-amber-800 rounded-2xl p-5 flex items-center justify-between"
     >
       <div>
-        <p class="text-sm font-semibold text-amber-900">
+        <p class="text-sm font-semibold text-amber-900 dark:text-amber-200">
           Track your net worth
         </p>
-        <p class="text-xs text-amber-700 mt-0.5">
+        <p class="text-xs text-amber-700 dark:text-amber-400 mt-0.5">
           Connect Coinbase, Bitcoin, or other accounts to see your total wealth.
         </p>
       </div>
@@ -93,19 +93,19 @@
     <!-- Lower grid -->
     <div class="grid grid-cols-1 lg:grid-cols-3 gap-6">
       <!-- Spending by Category -->
-      <div class="lg:col-span-2 bg-white rounded-2xl border border-gray-200 p-6">
-        <h2 class="text-base font-semibold text-gray-900 mb-4">
+      <div class="lg:col-span-2 bg-white dark:bg-gray-800 rounded-2xl border border-gray-200 dark:border-gray-700 p-6">
+        <h2 class="text-base font-semibold text-gray-900 dark:text-white mb-4">
           Spending by Category
         </h2>
         <div
           v-if="summaryLoading"
-          class="flex items-center justify-center h-48 text-gray-400 text-sm"
+          class="flex items-center justify-center h-48 text-gray-400 dark:text-gray-500 text-sm"
         >
           Loading…
         </div>
         <div
           v-else-if="categoryTotals.length === 0"
-          class="flex items-center justify-center h-48 text-gray-400 text-sm border-2 border-dashed border-gray-200 rounded-xl"
+          class="flex items-center justify-center h-48 text-gray-400 dark:text-gray-500 text-sm border-2 border-dashed border-gray-200 dark:border-gray-700 rounded-xl"
         >
           No spending data for this month
         </div>
@@ -119,10 +119,10 @@
             class="space-y-1"
           >
             <div class="flex justify-between text-sm">
-              <span class="text-gray-700 font-medium">{{ cat.categoryName }}</span>
-              <span class="text-gray-600">{{ formatMoney(cat.total) }}</span>
+              <span class="text-gray-700 dark:text-gray-300 font-medium">{{ cat.categoryName }}</span>
+              <span class="text-gray-600 dark:text-gray-400">{{ formatMoney(cat.total) }}</span>
             </div>
-            <div class="w-full h-2 bg-gray-100 rounded-full overflow-hidden">
+            <div class="w-full h-2 bg-gray-100 dark:bg-gray-700 rounded-full overflow-hidden">
               <div
                 class="h-full rounded-full bg-primary-500 transition-all"
                 :style="{ width: `${categoryBarPct(cat.total)}%` }"
@@ -133,19 +133,19 @@
       </div>
 
       <!-- Budget Progress -->
-      <div class="bg-white rounded-2xl border border-gray-200 p-6">
-        <h2 class="text-base font-semibold text-gray-900 mb-4">
+      <div class="bg-white dark:bg-gray-800 rounded-2xl border border-gray-200 dark:border-gray-700 p-6">
+        <h2 class="text-base font-semibold text-gray-900 dark:text-white mb-4">
           Budget Progress
         </h2>
         <div
           v-if="budgetsLoading"
-          class="text-sm text-gray-400"
+          class="text-sm text-gray-400 dark:text-gray-500"
         >
           Loading…
         </div>
         <div
           v-else-if="budgetsStore.budgets.length === 0"
-          class="flex items-center justify-center h-32 text-sm text-gray-400 border-2 border-dashed border-gray-200 rounded-xl"
+          class="flex items-center justify-center h-32 text-sm text-gray-400 dark:text-gray-500 border-2 border-dashed border-gray-200 dark:border-gray-700 rounded-xl"
         >
           No budgets set
         </div>
@@ -164,13 +164,13 @@
                   class="inline-block w-2.5 h-2.5 rounded-full flex-shrink-0"
                   :style="{ backgroundColor: budget.categoryColor }"
                 />
-                <span class="text-gray-700">{{ budget.categoryName }}</span>
+                <span class="text-gray-700 dark:text-gray-300">{{ budget.categoryName }}</span>
               </div>
-              <span class="text-gray-500 tabular-nums">
+              <span class="text-gray-500 dark:text-gray-400 tabular-nums">
                 {{ formatMoney(budget.spentAmount) }} / {{ formatMoney(budget.limitAmount) }}
               </span>
             </div>
-            <div class="w-full h-2 bg-gray-100 rounded-full overflow-hidden">
+            <div class="w-full h-2 bg-gray-100 dark:bg-gray-700 rounded-full overflow-hidden">
               <div
                 class="h-full rounded-full transition-all"
                 :class="budgetBarColor(budget)"
@@ -183,9 +183,9 @@
     </div>
 
     <!-- Recent Transactions -->
-    <div class="mt-6 bg-white rounded-2xl border border-gray-200 p-6">
+    <div class="mt-6 bg-white dark:bg-gray-800 rounded-2xl border border-gray-200 dark:border-gray-700 p-6">
       <div class="flex items-center justify-between mb-4">
-        <h2 class="text-base font-semibold text-gray-900">
+        <h2 class="text-base font-semibold text-gray-900 dark:text-white">
           Recent Transactions
         </h2>
         <RouterLink
@@ -197,19 +197,19 @@
       </div>
       <div
         v-if="summaryLoading"
-        class="flex items-center justify-center h-24 text-gray-400 text-sm"
+        class="flex items-center justify-center h-24 text-gray-400 dark:text-gray-500 text-sm"
       >
         Loading…
       </div>
       <div
         v-else-if="recentTransactions.length === 0"
-        class="flex items-center justify-center h-24 text-gray-400 text-sm border-2 border-dashed border-gray-200 rounded-xl"
+        class="flex items-center justify-center h-24 text-gray-400 dark:text-gray-500 text-sm border-2 border-dashed border-gray-200 dark:border-gray-700 rounded-xl"
       >
         No transactions this month
       </div>
       <ul
         v-else
-        class="divide-y divide-gray-100"
+        class="divide-y divide-gray-100 dark:divide-gray-700"
       >
         <li
           v-for="tx in recentTransactions"
@@ -217,10 +217,10 @@
           class="flex items-center justify-between py-3 first:pt-0 last:pb-0"
         >
           <div class="flex flex-col min-w-0">
-            <span class="text-sm font-medium text-gray-800 truncate">
+            <span class="text-sm font-medium text-gray-800 dark:text-gray-200 truncate">
               {{ tx.description || tx.categoryName }}
             </span>
-            <span class="text-xs text-gray-400 mt-0.5">
+            <span class="text-xs text-gray-400 dark:text-gray-500 mt-0.5">
               {{ tx.categoryName }} · {{ formatDate(tx.date, false) }}
             </span>
           </div>

--- a/frontend/src/views/NetWorthView.vue
+++ b/frontend/src/views/NetWorthView.vue
@@ -1,24 +1,24 @@
 <template>
   <div class="px-6 py-8 max-w-7xl mx-auto">
     <div class="mb-6">
-      <h1 class="text-2xl font-bold text-gray-900">
+      <h1 class="text-2xl font-bold text-gray-900 dark:text-white">
         Net Worth
       </h1>
-      <p class="mt-1 text-sm text-gray-500">
+      <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
         Your total wealth across all connected accounts.
       </p>
     </div>
 
     <div
       v-if="loading"
-      class="flex items-center justify-center h-64 text-gray-400 text-sm"
+      class="flex items-center justify-center h-64 text-gray-400 dark:text-gray-500 text-sm"
     >
       Loading…
     </div>
 
     <div
       v-else-if="loadError"
-      class="bg-white rounded-2xl border border-gray-200 flex flex-col items-center justify-center h-64 gap-3"
+      class="bg-white dark:bg-gray-800 rounded-2xl border border-gray-200 dark:border-gray-700 flex flex-col items-center justify-center h-64 gap-3"
     >
       <p class="text-sm text-red-600">
         {{ loadError }}
@@ -33,16 +33,16 @@
 
     <template v-else>
       <!-- Total net worth card -->
-      <div class="bg-white rounded-2xl border border-gray-200 p-6 mb-6">
-        <p class="text-sm text-gray-500 mb-1">
+      <div class="bg-white dark:bg-gray-800 rounded-2xl border border-gray-200 dark:border-gray-700 p-6 mb-6">
+        <p class="text-sm text-gray-500 dark:text-gray-400 mb-1">
           Total Net Worth
         </p>
-        <p class="text-3xl font-bold text-gray-900">
+        <p class="text-3xl font-bold text-gray-900 dark:text-white">
           {{ formatMoney(store.netWorth?.totalNetWorthUsd ?? 0) }}
         </p>
         <p
           v-if="store.netWorth?.asOf"
-          class="text-xs text-gray-400 mt-2"
+          class="text-xs text-gray-400 dark:text-gray-500 mt-2"
         >
           As of {{ new Date(store.netWorth.asOf).toLocaleString() }}
         </p>
@@ -51,13 +51,13 @@
       <!-- Breakdown cards -->
       <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6">
         <!-- By Provider -->
-        <div class="bg-white rounded-2xl border border-gray-200 p-6">
-          <h2 class="text-sm font-semibold text-gray-700 uppercase tracking-wide mb-4">
+        <div class="bg-white dark:bg-gray-800 rounded-2xl border border-gray-200 dark:border-gray-700 p-6">
+          <h2 class="text-sm font-semibold text-gray-700 dark:text-gray-300 uppercase tracking-wide mb-4">
             By Provider
           </h2>
           <div
             v-if="(store.netWorth?.byProvider ?? []).length === 0"
-            class="text-sm text-gray-400"
+            class="text-sm text-gray-400 dark:text-gray-500"
           >
             No connected providers.
           </div>
@@ -78,15 +78,15 @@
                   {{ providerIcon(p.providerType) }}
                 </div>
                 <div>
-                  <p class="text-sm font-medium text-gray-900">
+                  <p class="text-sm font-medium text-gray-900 dark:text-white">
                     {{ providerLabel(p.providerType) }}
                   </p>
-                  <p class="text-xs text-gray-500">
+                  <p class="text-xs text-gray-500 dark:text-gray-400">
                     {{ p.accountCount }} account{{ p.accountCount !== 1 ? 's' : '' }}
                   </p>
                 </div>
               </div>
-              <p class="text-sm font-semibold text-gray-900 tabular-nums">
+              <p class="text-sm font-semibold text-gray-900 dark:text-white tabular-nums">
                 {{ formatMoney(p.totalUsd) }}
               </p>
             </div>
@@ -94,13 +94,13 @@
         </div>
 
         <!-- By Account Type -->
-        <div class="bg-white rounded-2xl border border-gray-200 p-6">
-          <h2 class="text-sm font-semibold text-gray-700 uppercase tracking-wide mb-4">
+        <div class="bg-white dark:bg-gray-800 rounded-2xl border border-gray-200 dark:border-gray-700 p-6">
+          <h2 class="text-sm font-semibold text-gray-700 dark:text-gray-300 uppercase tracking-wide mb-4">
             By Account Type
           </h2>
           <div
             v-if="(store.netWorth?.byAccountType ?? []).length === 0"
-            class="text-sm text-gray-400"
+            class="text-sm text-gray-400 dark:text-gray-500"
           >
             No accounts yet.
           </div>
@@ -114,14 +114,14 @@
               class="flex items-center justify-between"
             >
               <div>
-                <p class="text-sm font-medium text-gray-900">
+                <p class="text-sm font-medium text-gray-900 dark:text-white">
                   {{ accountTypeLabel(a.accountType) }}
                 </p>
-                <p class="text-xs text-gray-500">
+                <p class="text-xs text-gray-500 dark:text-gray-400">
                   {{ a.accountCount }} account{{ a.accountCount !== 1 ? 's' : '' }}
                 </p>
               </div>
-              <p class="text-sm font-semibold text-gray-900 tabular-nums">
+              <p class="text-sm font-semibold text-gray-900 dark:text-white tabular-nums">
                 {{ formatMoney(a.totalUsd) }}
               </p>
             </div>
@@ -130,14 +130,14 @@
       </div>
 
       <!-- History table -->
-      <div class="bg-white rounded-2xl border border-gray-200 p-6">
+      <div class="bg-white dark:bg-gray-800 rounded-2xl border border-gray-200 dark:border-gray-700 p-6">
         <div class="flex items-center justify-between mb-4">
-          <h2 class="text-sm font-semibold text-gray-700 uppercase tracking-wide">
+          <h2 class="text-sm font-semibold text-gray-700 dark:text-gray-300 uppercase tracking-wide">
             History
           </h2>
           <select
             v-model.number="historyDays"
-            class="text-sm border border-gray-300 rounded-lg px-3 py-1.5 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+            class="text-sm border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-1.5 bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
             @change="loadHistory"
           >
             <option :value="7">
@@ -157,13 +157,13 @@
 
         <div
           v-if="historyLoading"
-          class="text-sm text-gray-400 text-center py-8"
+          class="text-sm text-gray-400 dark:text-gray-500 text-center py-8"
         >
           Loading history…
         </div>
         <div
           v-else-if="store.netWorthHistory.length === 0"
-          class="text-sm text-gray-400 text-center py-8"
+          class="text-sm text-gray-400 dark:text-gray-500 text-center py-8"
         >
           No history data yet. Connect accounts and sync to start tracking.
         </div>
@@ -173,25 +173,25 @@
         >
           <table class="w-full text-sm">
             <thead>
-              <tr class="border-b border-gray-100">
-                <th class="text-left px-4 py-2 text-xs font-semibold text-gray-500 uppercase">
+              <tr class="border-b border-gray-100 dark:border-gray-700">
+                <th class="text-left px-4 py-2 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase">
                   Date
                 </th>
-                <th class="text-right px-4 py-2 text-xs font-semibold text-gray-500 uppercase">
+                <th class="text-right px-4 py-2 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase">
                   Net Worth
                 </th>
               </tr>
             </thead>
-            <tbody class="divide-y divide-gray-50">
+            <tbody class="divide-y divide-gray-50 dark:divide-gray-700">
               <tr
                 v-for="dp in store.netWorthHistory"
                 :key="dp.date"
-                class="hover:bg-gray-50"
+                class="hover:bg-gray-50 dark:hover:bg-gray-700"
               >
-                <td class="px-4 py-2 text-gray-600">
+                <td class="px-4 py-2 text-gray-600 dark:text-gray-400">
                   {{ dp.date }}
                 </td>
-                <td class="px-4 py-2 text-right font-semibold text-gray-900 tabular-nums">
+                <td class="px-4 py-2 text-right font-semibold text-gray-900 dark:text-white tabular-nums">
                   {{ formatMoney(dp.totalUsd) }}
                 </td>
               </tr>

--- a/frontend/src/views/NotFoundView.vue
+++ b/frontend/src/views/NotFoundView.vue
@@ -1,13 +1,13 @@
 <template>
-  <div class="min-h-screen flex items-center justify-center bg-gray-50 px-4">
+  <div class="min-h-screen flex items-center justify-center bg-gray-50 dark:bg-gray-900 px-4">
     <div class="text-center">
       <p class="text-7xl font-black text-primary-600 mb-4">
         404
       </p>
-      <h1 class="text-2xl font-bold text-gray-900 mb-2">
+      <h1 class="text-2xl font-bold text-gray-900 dark:text-white mb-2">
         Page not found
       </h1>
-      <p class="text-gray-500 mb-8">
+      <p class="text-gray-500 dark:text-gray-400 mb-8">
         The page you're looking for doesn't exist.
       </p>
       <RouterLink

--- a/frontend/src/views/SettingsView.vue
+++ b/frontend/src/views/SettingsView.vue
@@ -67,7 +67,11 @@
             class="text-sm border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-1.5 bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
             @change="handleCurrencyChange"
           >
-            <option v-for="c in currencies" :key="c.code" :value="c.code">
+            <option
+              v-for="c in currencies"
+              :key="c.code"
+              :value="c.code"
+            >
               {{ c.code }} — {{ c.label }}
             </option>
           </select>
@@ -81,7 +85,7 @@
 
     <!-- Danger zone -->
     <div class="bg-white dark:bg-gray-800 rounded-2xl border border-red-200 dark:border-red-900 p-6">
-      <h2 class="text-base font-semibold text-red-700 mb-4">
+      <h2 class="text-base font-semibold text-red-700 dark:text-red-400 mb-4">
         Danger Zone
       </h2>
       <div class="flex items-center justify-between">
@@ -94,7 +98,7 @@
           </p>
         </div>
         <button
-          class="px-4 py-2 text-sm font-medium text-red-600 border border-red-300 rounded-lg hover:bg-red-50 transition-colors"
+          class="px-4 py-2 text-sm font-medium text-red-600 dark:text-red-400 border border-red-300 dark:border-red-700 rounded-lg hover:bg-red-50 dark:hover:bg-red-900/30 transition-colors"
           @click="handleLogout"
         >
           Sign out

--- a/frontend/src/views/TransactionsView.vue
+++ b/frontend/src/views/TransactionsView.vue
@@ -2,42 +2,52 @@
   <div class="px-6 py-8 max-w-7xl mx-auto">
     <div class="flex items-center justify-between mb-6">
       <div>
-        <h1 class="text-2xl font-bold text-gray-900">
+        <h1 class="text-2xl font-bold text-gray-900 dark:text-white">
           Transactions
         </h1>
-        <p class="mt-1 text-sm text-gray-500">
+        <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
           Track every dollar in and out.
         </p>
       </div>
       <div class="flex items-center gap-2">
-      <button
-        class="flex items-center gap-2 px-4 py-2 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 text-sm font-medium rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
-        @click="showImportModal = true"
-      >
-        <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-8l-4-4m0 0L8 8m4-4v12" />
-        </svg>
-        Import CSV
-      </button>
-      <button
-        class="flex items-center gap-2 px-4 py-2 bg-primary-600 text-white text-sm font-medium rounded-lg hover:bg-primary-700 transition-colors"
-        @click="showAddModal = true"
-      >
-        <svg
-          class="w-4 h-4"
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor"
-          stroke-width="2"
+        <button
+          class="flex items-center gap-2 px-4 py-2 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 text-sm font-medium rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
+          @click="showImportModal = true"
         >
-          <path
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            d="M12 4v16m8-8H4"
-          />
-        </svg>
-        Add Transaction
-      </button>
+          <svg
+            class="w-4 h-4"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            stroke-width="2"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-8l-4-4m0 0L8 8m4-4v12"
+            />
+          </svg>
+          Import CSV
+        </button>
+        <button
+          class="flex items-center gap-2 px-4 py-2 bg-primary-600 text-white text-sm font-medium rounded-lg hover:bg-primary-700 transition-colors"
+          @click="showAddModal = true"
+        >
+          <svg
+            class="w-4 h-4"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            stroke-width="2"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d="M12 4v16m8-8H4"
+            />
+          </svg>
+          Add Transaction
+        </button>
       </div>
     </div>
 
@@ -110,16 +120,16 @@
     </div>
 
     <!-- Filters -->
-    <div class="bg-white rounded-2xl border border-gray-200 p-4 mb-4 flex flex-wrap gap-3">
+    <div class="bg-white dark:bg-gray-800 rounded-2xl border border-gray-200 dark:border-gray-700 p-4 mb-4 flex flex-wrap gap-3">
       <input
         v-model="selectedMonth"
         type="month"
-        class="text-sm border border-gray-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+        class="text-sm border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
         @change="onFilterChange"
       >
       <select
         v-model="selectedCategoryId"
-        class="text-sm border border-gray-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+        class="text-sm border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
         @change="onFilterChange"
       >
         <option value="">
@@ -133,7 +143,7 @@
           {{ cat.name }}
         </option>
       </select>
-      <div class="flex rounded-lg border border-gray-300 overflow-hidden text-sm">
+      <div class="flex rounded-lg border border-gray-300 dark:border-gray-600 overflow-hidden text-sm">
         <button
           v-for="opt in typeOptions"
           :key="opt.value"
@@ -141,7 +151,7 @@
           :class="
             selectedType === opt.value
               ? 'bg-primary-600 text-white'
-              : 'bg-white text-gray-700 hover:bg-gray-50'
+              : 'bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-600'
           "
           @click="selectType(opt.value)"
         >
@@ -151,20 +161,20 @@
     </div>
 
     <!-- Transaction list -->
-    <div class="bg-white rounded-2xl border border-gray-200 overflow-hidden">
+    <div class="bg-white dark:bg-gray-800 rounded-2xl border border-gray-200 dark:border-gray-700 overflow-hidden">
       <div
         v-if="loading"
-        class="flex items-center justify-center h-64 text-gray-400 text-sm"
+        class="flex items-center justify-center h-64 text-gray-400 dark:text-gray-500 text-sm"
       >
         Loading…
       </div>
       <div
         v-else-if="transactionsStore.transactions.length === 0"
-        class="flex items-center justify-center h-64 text-gray-400 text-sm"
+        class="flex items-center justify-center h-64 text-gray-400 dark:text-gray-500 text-sm"
       >
         <div class="text-center">
           <svg
-            class="w-10 h-10 mx-auto mb-3 text-gray-300"
+            class="w-10 h-10 mx-auto mb-3 text-gray-300 dark:text-gray-600"
             fill="none"
             viewBox="0 0 24 24"
             stroke="currentColor"
@@ -176,10 +186,10 @@
               d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"
             />
           </svg>
-          <p class="font-medium text-gray-500">
+          <p class="font-medium text-gray-500 dark:text-gray-400">
             No transactions found
           </p>
-          <p class="text-xs mt-1">
+          <p class="text-xs mt-1 dark:text-gray-500">
             Add your first transaction to get started.
           </p>
         </div>
@@ -189,39 +199,39 @@
         class="w-full text-sm"
       >
         <thead>
-          <tr class="border-b border-gray-100 text-left">
-            <th class="px-6 py-3 text-xs font-semibold text-gray-500 uppercase tracking-wide">
+          <tr class="border-b border-gray-100 dark:border-gray-700 text-left">
+            <th class="px-6 py-3 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">
               Date
             </th>
-            <th class="px-6 py-3 text-xs font-semibold text-gray-500 uppercase tracking-wide">
+            <th class="px-6 py-3 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">
               Description
             </th>
-            <th class="px-6 py-3 text-xs font-semibold text-gray-500 uppercase tracking-wide">
+            <th class="px-6 py-3 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">
               Category
             </th>
             <th
-              class="px-6 py-3 text-xs font-semibold text-gray-500 uppercase tracking-wide text-right"
+              class="px-6 py-3 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide text-right"
             >
               Amount
             </th>
-            <th class="px-6 py-3 text-xs font-semibold text-gray-500 uppercase tracking-wide w-20">
+            <th class="px-6 py-3 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide w-20">
               Actions
             </th>
           </tr>
         </thead>
-        <tbody class="divide-y divide-gray-50">
+        <tbody class="divide-y divide-gray-50 dark:divide-gray-700">
           <tr
             v-for="tx in transactionsStore.transactions"
             :key="tx.id"
-            class="hover:bg-gray-50 transition-colors"
+            class="hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
           >
-            <td class="px-6 py-4 text-gray-500 tabular-nums whitespace-nowrap">
+            <td class="px-6 py-4 text-gray-500 dark:text-gray-400 tabular-nums whitespace-nowrap">
               {{ formatDate(tx.date) }}
             </td>
-            <td class="px-6 py-4 text-gray-800 font-medium">
+            <td class="px-6 py-4 text-gray-800 dark:text-gray-200 font-medium">
               {{ tx.description || '—' }}
             </td>
-            <td class="px-6 py-4 text-gray-500">
+            <td class="px-6 py-4 text-gray-500 dark:text-gray-400">
               {{ tx.categoryName }}
             </td>
             <td
@@ -280,7 +290,7 @@
     <!-- Pagination -->
     <div
       v-if="transactionsStore.pagination.totalPages > 1"
-      class="flex items-center justify-between mt-4 text-sm text-gray-600"
+      class="flex items-center justify-between mt-4 text-sm text-gray-600 dark:text-gray-400"
     >
       <span>
         Page {{ transactionsStore.pagination.currentPage + 1 }} of
@@ -289,14 +299,14 @@
       </span>
       <div class="flex gap-2">
         <button
-          class="px-3 py-1.5 rounded-lg border border-gray-300 hover:bg-gray-50 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+          class="px-3 py-1.5 rounded-lg border border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-700 dark:text-gray-300 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
           :disabled="transactionsStore.pagination.currentPage === 0"
           @click="changePage(transactionsStore.pagination.currentPage - 1)"
         >
           Previous
         </button>
         <button
-          class="px-3 py-1.5 rounded-lg border border-gray-300 hover:bg-gray-50 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+          class="px-3 py-1.5 rounded-lg border border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-700 dark:text-gray-300 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
           :disabled="
             transactionsStore.pagination.currentPage === transactionsStore.pagination.totalPages - 1
           "
@@ -313,13 +323,13 @@
       class="fixed inset-0 z-50 flex items-center justify-center bg-gray-900/50"
       @mousedown.self="showAddModal = false"
     >
-      <div class="bg-white rounded-2xl shadow-xl w-full max-w-md mx-4 p-6">
+      <div class="bg-white dark:bg-gray-800 rounded-2xl shadow-xl w-full max-w-md mx-4 p-6">
         <div class="flex items-center justify-between mb-5">
-          <h2 class="text-lg font-semibold text-gray-900">
+          <h2 class="text-lg font-semibold text-gray-900 dark:text-white">
             Add Transaction
           </h2>
           <button
-            class="text-gray-400 hover:text-gray-600"
+            class="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
             @click="showAddModal = false"
           >
             <svg
@@ -344,15 +354,15 @@
         >
           <!-- Type toggle -->
           <div>
-            <label class="block text-sm font-medium text-gray-700 mb-1">Type</label>
-            <div class="flex rounded-lg border border-gray-300 overflow-hidden text-sm">
+            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Type</label>
+            <div class="flex rounded-lg border border-gray-300 dark:border-gray-600 overflow-hidden text-sm">
               <button
                 type="button"
                 class="flex-1 py-2 transition-colors"
                 :class="
                   form.type === 'EXPENSE'
                     ? 'bg-red-500 text-white'
-                    : 'bg-white text-gray-700 hover:bg-gray-50'
+                    : 'bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-600'
                 "
                 @click="form.type = 'EXPENSE'"
               >
@@ -364,7 +374,7 @@
                 :class="
                   form.type === 'INCOME'
                     ? 'bg-emerald-500 text-white'
-                    : 'bg-white text-gray-700 hover:bg-gray-50'
+                    : 'bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-600'
                 "
                 @click="form.type = 'INCOME'"
               >
@@ -375,7 +385,7 @@
 
           <!-- Amount -->
           <div>
-            <label class="block text-sm font-medium text-gray-700 mb-1">Amount</label>
+            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Amount</label>
             <div class="relative">
               <span class="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 text-sm">$</span>
               <input
@@ -385,14 +395,14 @@
                 min="0.01"
                 required
                 placeholder="0.00"
-                class="w-full pl-7 pr-3 py-2 text-sm border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+                class="w-full pl-7 pr-3 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
               >
             </div>
           </div>
 
           <!-- Description -->
           <div>
-            <label class="block text-sm font-medium text-gray-700 mb-1">
+            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
               Description
               <span class="text-gray-400 font-normal">(optional)</span>
             </label>
@@ -400,28 +410,28 @@
               v-model="form.description"
               type="text"
               placeholder="e.g. Grocery run"
-              class="w-full px-3 py-2 text-sm border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+              class="w-full px-3 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
             >
           </div>
 
           <!-- Date -->
           <div>
-            <label class="block text-sm font-medium text-gray-700 mb-1">Date</label>
+            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Date</label>
             <input
               v-model="form.date"
               type="date"
               required
-              class="w-full px-3 py-2 text-sm border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+              class="w-full px-3 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
             >
           </div>
 
           <!-- Category -->
           <div>
-            <label class="block text-sm font-medium text-gray-700 mb-1">Category</label>
+            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Category</label>
             <select
               v-model.number="form.categoryId"
               required
-              class="w-full px-3 py-2 text-sm border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+              class="w-full px-3 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
             >
               <option
                 value=""
@@ -451,7 +461,7 @@
           <div class="flex gap-3 pt-1">
             <button
               type="button"
-              class="flex-1 px-4 py-2 text-sm font-medium text-gray-700 border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors"
+              class="flex-1 px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
               @click="showAddModal = false"
             >
               Cancel
@@ -474,13 +484,13 @@
       class="fixed inset-0 z-50 flex items-center justify-center bg-gray-900/50"
       @mousedown.self="showEditModal = false"
     >
-      <div class="bg-white rounded-2xl shadow-xl w-full max-w-md mx-4 p-6">
+      <div class="bg-white dark:bg-gray-800 rounded-2xl shadow-xl w-full max-w-md mx-4 p-6">
         <div class="flex items-center justify-between mb-5">
-          <h2 class="text-lg font-semibold text-gray-900">
+          <h2 class="text-lg font-semibold text-gray-900 dark:text-white">
             Edit Transaction
           </h2>
           <button
-            class="text-gray-400 hover:text-gray-600"
+            class="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
             @click="showEditModal = false"
           >
             <svg
@@ -504,12 +514,12 @@
           @submit.prevent="submitEdit"
         >
           <div>
-            <label class="block text-sm font-medium text-gray-700 mb-1">Type</label>
-            <div class="flex rounded-lg border border-gray-300 overflow-hidden text-sm">
+            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Type</label>
+            <div class="flex rounded-lg border border-gray-300 dark:border-gray-600 overflow-hidden text-sm">
               <button
                 type="button"
                 class="flex-1 py-2 transition-colors"
-                :class="editForm.type === 'EXPENSE' ? 'bg-red-500 text-white' : 'bg-white text-gray-700 hover:bg-gray-50'"
+                :class="editForm.type === 'EXPENSE' ? 'bg-red-500 text-white' : 'bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-600'"
                 @click="editForm.type = 'EXPENSE'"
               >
                 Expense
@@ -517,7 +527,7 @@
               <button
                 type="button"
                 class="flex-1 py-2 transition-colors"
-                :class="editForm.type === 'INCOME' ? 'bg-emerald-500 text-white' : 'bg-white text-gray-700 hover:bg-gray-50'"
+                :class="editForm.type === 'INCOME' ? 'bg-emerald-500 text-white' : 'bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-600'"
                 @click="editForm.type = 'INCOME'"
               >
                 Income
@@ -526,7 +536,7 @@
           </div>
 
           <div>
-            <label class="block text-sm font-medium text-gray-700 mb-1">Amount</label>
+            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Amount</label>
             <div class="relative">
               <span class="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 text-sm">$</span>
               <input
@@ -535,39 +545,39 @@
                 step="0.01"
                 min="0.01"
                 required
-                class="w-full pl-7 pr-3 py-2 text-sm border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+                class="w-full pl-7 pr-3 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
               >
             </div>
           </div>
 
           <div>
-            <label class="block text-sm font-medium text-gray-700 mb-1">
+            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
               Description
               <span class="text-gray-400 font-normal">(optional)</span>
             </label>
             <input
               v-model="editForm.description"
               type="text"
-              class="w-full px-3 py-2 text-sm border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+              class="w-full px-3 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
             >
           </div>
 
           <div>
-            <label class="block text-sm font-medium text-gray-700 mb-1">Date</label>
+            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Date</label>
             <input
               v-model="editForm.date"
               type="date"
               required
-              class="w-full px-3 py-2 text-sm border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+              class="w-full px-3 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
             >
           </div>
 
           <div>
-            <label class="block text-sm font-medium text-gray-700 mb-1">Category</label>
+            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Category</label>
             <select
               v-model.number="editForm.categoryId"
               required
-              class="w-full px-3 py-2 text-sm border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+              class="w-full px-3 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
             >
               <option
                 value=""
@@ -595,7 +605,7 @@
           <div class="flex gap-3 pt-1">
             <button
               type="button"
-              class="flex-1 px-4 py-2 text-sm font-medium text-gray-700 border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors"
+              class="flex-1 px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
               @click="showEditModal = false"
             >
               Cancel
@@ -618,11 +628,11 @@
       class="fixed inset-0 z-50 flex items-center justify-center bg-gray-900/50"
       @mousedown.self="showDeleteModal = false"
     >
-      <div class="bg-white rounded-2xl shadow-xl w-full max-w-sm mx-4 p-6">
-        <h2 class="text-lg font-semibold text-gray-900 mb-2">
+      <div class="bg-white dark:bg-gray-800 rounded-2xl shadow-xl w-full max-w-sm mx-4 p-6">
+        <h2 class="text-lg font-semibold text-gray-900 dark:text-white mb-2">
           Delete Transaction
         </h2>
-        <p class="text-sm text-gray-600 mb-5">
+        <p class="text-sm text-gray-600 dark:text-gray-300 mb-5">
           Are you sure you want to delete this
           <span class="font-medium">{{ formatMoney(deleteTarget?.amount ?? 0) }}</span>
           transaction? This action cannot be undone.
@@ -638,7 +648,7 @@
         <div class="flex gap-3">
           <button
             type="button"
-            class="flex-1 px-4 py-2 text-sm font-medium text-gray-700 border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors"
+            class="flex-1 px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
             @click="showDeleteModal = false"
           >
             Cancel

--- a/frontend/src/views/auth/LoginView.vue
+++ b/frontend/src/views/auth/LoginView.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="min-h-screen flex items-center justify-center bg-gray-50 px-4">
+  <div class="min-h-screen flex items-center justify-center bg-gray-50 dark:bg-gray-900 px-4">
     <div class="w-full max-w-sm">
       <!-- Logo -->
       <div class="text-center mb-8">
@@ -20,23 +20,23 @@
             />
           </svg>
         </div>
-        <h1 class="text-2xl font-bold text-gray-900">
+        <h1 class="text-2xl font-bold text-gray-900 dark:text-white">
           KeyBudget
         </h1>
-        <p class="mt-1 text-sm text-gray-500">
+        <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
           Take control of your finances
         </p>
       </div>
 
       <!-- Card -->
-      <div class="bg-white rounded-2xl shadow-sm border border-gray-200 p-8">
-        <h2 class="text-lg font-semibold text-gray-900 mb-6">
+      <div class="bg-white dark:bg-gray-800 rounded-2xl shadow-sm border border-gray-200 dark:border-gray-700 p-8">
+        <h2 class="text-lg font-semibold text-gray-900 dark:text-white mb-6">
           Sign in to your account
         </h2>
 
         <a
           :href="googleOAuthUrl"
-          class="flex items-center justify-center gap-3 w-full px-4 py-2.5 border border-gray-300 rounded-lg text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 transition-colors"
+          class="flex items-center justify-center gap-3 w-full px-4 py-2.5 border border-gray-300 dark:border-gray-600 rounded-lg text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 transition-colors"
         >
           <!-- Google G logo -->
           <svg
@@ -63,16 +63,16 @@
           Continue with Google
         </a>
 
-        <p class="mt-6 text-xs text-center text-gray-400">
+        <p class="mt-6 text-xs text-center text-gray-400 dark:text-gray-500">
           By signing in, you agree to our
           <a
             href="#"
-            class="underline hover:text-gray-600"
+            class="underline hover:text-gray-600 dark:hover:text-gray-300"
           >Terms</a>
           and
           <a
             href="#"
-            class="underline hover:text-gray-600"
+            class="underline hover:text-gray-600 dark:hover:text-gray-300"
           >Privacy Policy</a>.
         </p>
       </div>

--- a/frontend/src/views/auth/OAuthCallbackView.vue
+++ b/frontend/src/views/auth/OAuthCallbackView.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="min-h-screen flex items-center justify-center bg-gray-50">
+  <div class="min-h-screen flex items-center justify-center bg-gray-50 dark:bg-gray-900">
     <div class="text-center">
       <div
         v-if="error"
@@ -20,10 +20,10 @@
             />
           </svg>
         </div>
-        <p class="text-gray-700 font-medium mb-2">
+        <p class="text-gray-700 dark:text-gray-300 font-medium mb-2">
           Sign-in failed
         </p>
-        <p class="text-sm text-gray-500 mb-4">
+        <p class="text-sm text-gray-500 dark:text-gray-400 mb-4">
           {{ error }}
         </p>
         <RouterLink
@@ -57,7 +57,7 @@
             d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
           />
         </svg>
-        <p class="text-sm text-gray-500">
+        <p class="text-sm text-gray-500 dark:text-gray-400">
           Signing you in…
         </p>
       </div>

--- a/scripts/start-dev.sh
+++ b/scripts/start-dev.sh
@@ -79,8 +79,14 @@ echo "Starting KeyBudget..."
 echo "  Backend:  http://localhost:8080"
 echo "  Frontend: http://localhost:5173"
 echo "  Health:   http://localhost:8080/actuator/health"
+echo "  Logs:     $PROJECT_DIR/logs/"
 echo "  Press Ctrl+C to stop both servers"
 echo ""
+
+# Create logs directory
+LOG_DIR="$PROJECT_DIR/logs"
+mkdir -p "$LOG_DIR"
+export LOG_DIR
 
 # Install frontend deps if needed
 if [ ! -d "$FRONTEND_DIR/node_modules" ]; then
@@ -88,14 +94,14 @@ if [ ! -d "$FRONTEND_DIR/node_modules" ]; then
     (cd "$FRONTEND_DIR" && npm install) || { echo "ERROR: npm install failed"; exit 1; }
 fi
 
-# Start frontend in background
+# Start frontend in background — tee to log file
 cd "$FRONTEND_DIR"
-npx vite --host &
+npx vite --host 2>&1 | tee "$LOG_DIR/frontend.log" &
 FRONTEND_PID=$!
 
-# Start backend in background
+# Start backend in background (logback-spring.xml writes to LOG_DIR/backend.log)
 cd "$BACKEND_DIR"
-./mvnw spring-boot:run -Dspring-boot.run.profiles=dev &
+./mvnw spring-boot:run -Dspring-boot.run.profiles=dev "-Dspring-boot.run.jvmArguments=-DLOG_DIR=$LOG_DIR" 2>&1 | tee "$LOG_DIR/backend-console.log" &
 BACKEND_PID=$!
 
 echo "Frontend PID: $FRONTEND_PID | Backend PID: $BACKEND_PID"

--- a/scripts/start-dev.sh
+++ b/scripts/start-dev.sh
@@ -94,14 +94,14 @@ if [ ! -d "$FRONTEND_DIR/node_modules" ]; then
     (cd "$FRONTEND_DIR" && npm install) || { echo "ERROR: npm install failed"; exit 1; }
 fi
 
-# Start frontend in background — tee to log file
+# Start frontend in background — log to file AND show in terminal
 cd "$FRONTEND_DIR"
-npx vite --host 2>&1 | tee "$LOG_DIR/frontend.log" &
+npx vite --host > >(tee -a "$LOG_DIR/frontend.log") 2>&1 &
 FRONTEND_PID=$!
 
 # Start backend in background (logback-spring.xml writes to LOG_DIR/backend.log)
 cd "$BACKEND_DIR"
-./mvnw spring-boot:run -Dspring-boot.run.profiles=dev "-Dspring-boot.run.jvmArguments=-DLOG_DIR=$LOG_DIR" 2>&1 | tee "$LOG_DIR/backend-console.log" &
+./mvnw spring-boot:run -Dspring-boot.run.profiles=dev "-Dspring-boot.run.jvmArguments=-DLOG_DIR=$LOG_DIR" > >(tee -a "$LOG_DIR/backend-console.log") 2>&1 &
 BACKEND_PID=$!
 
 echo "Frontend PID: $FRONTEND_PID | Backend PID: $BACKEND_PID"


### PR DESCRIPTION
## Summary
- Add dark mode (Tailwind `dark:` classes) to all 10 view files
- Replace Plaid-dependent M1 Finance and Marcus providers with manual balance entry
- Remove all Plaid Link code from AccountsView frontend
- Add logback file-based logging (rolling, 10MB, dev/prod profiles)
- Fix start-dev.sh process death (pipe ? process substitution)

## Why
Plaid Development keys require a business application. Manual balance entry lets us track M1 Finance and Marcus account balances immediately without external dependencies.

## Test plan
- [ ] Backend compiles with new providers ?
- [ ] Frontend builds with Plaid code removed ?
- [ ] Connect M1 Finance with manual balance entry
- [ ] Connect Marcus with manual balance entry
- [ ] Bitcoin wallet integration still works
- [ ] Dark mode renders correctly on all views
- [ ] start-dev.sh keeps both processes alive
- [ ] Logs written to logs/backend.log

Closes #13
Closes #14

?? Generated with [Claude Code](https://claude.com/claude-code)